### PR TITLE
Fix missed response schema cases, add `backup_name`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,23 +116,32 @@ pub fn parse_openapi(
     }
 
     // Parse paths
-    for (_path, path_item) in openapi.paths.iter() {
+    for (path, path_item) in openapi.paths.iter() {
         let path_item = match path_item {
             ReferenceOr::Item(item) => item,
             ReferenceOr::Reference { .. } => continue,
         };
 
         let operations = [
-            &path_item.get,
-            &path_item.post,
-            &path_item.put,
-            &path_item.delete,
-            &path_item.patch,
+            ("GET", &path_item.get),
+            ("POST", &path_item.post),
+            ("PUT", &path_item.put),
+            ("DELETE", &path_item.delete),
+            ("PATCH", &path_item.patch),
         ];
 
-        for op in operations.iter().filter_map(|o| o.as_ref()) {
+        for (method, op) in operations.iter().filter_map(|(m, o)| o.as_ref().map(|operation| (*m, operation))) {
+            let backup_name = format!(
+                "{}{}", 
+                method, 
+                to_pascal_case(&path
+                    .replace('/', "-")
+                    .replace('{', "-")
+                    .replace('}', "")
+                )
+            );
             let inline_models =
-                process_operation(op, &mut requests, &mut responses, schemas, request_bodies)?;
+                process_operation(op, &mut requests, &mut responses, schemas, request_bodies, &backup_name)?;
             for model_type in inline_models {
                 if added_models.insert(model_type.name().to_string()) {
                     models.push(model_type);
@@ -150,6 +159,7 @@ fn process_operation(
     responses: &mut Vec<ResponseModel>,
     all_schemas: &IndexMap<String, ReferenceOr<Schema>>,
     request_bodies: &IndexMap<String, ReferenceOr<openapiv3::RequestBody>>,
+    backup_name: &str
 ) -> Result<Vec<ModelType>> {
     let mut inline_models = Vec::new();
 
@@ -176,8 +186,7 @@ fn process_operation(
             for (content_type, media_type) in &request_body.content {
                 if let Some(schema) = &media_type.schema {
                     let operation_name =
-                        to_pascal_case(operation.operation_id.as_deref().unwrap_or("Unknown"));
-
+                        to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
                     let schema_type = if is_inline {
                         if let ReferenceOr::Item(schema_item) = schema {
                             if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_)))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -187,6 +187,7 @@ fn process_operation(
                 if let Some(schema) = &media_type.schema {
                     let operation_name =
                         to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
+
                     let schema_type = if is_inline {
                         if let ReferenceOr::Item(schema_item) = schema {
                             if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_)))
@@ -225,6 +226,7 @@ fn process_operation(
                 if let Some(schema) = &media_type.schema {
                     let operation_name =
                         to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
+
                     let schema_type = if let ReferenceOr::Item(schema_item) = schema {
                         if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_)))
                         {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -357,6 +357,7 @@ fn parse_schema_to_model_type(
                                 inline_models.extend(nested_models);
                             }
                         }
+                        
                         let (field_info, inline_model) = match field_schema {
                             ReferenceOr::Item(boxed_schema) => extract_field_info(
                                 field_name,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -231,12 +231,23 @@ fn process_operation(
                 if let Some(schema) = &media_type.schema {
                     let operation_name =
                         to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
-
+                    let mut is_array = false;
                     let schema_type = if let ReferenceOr::Item(schema_item) = schema {
                         if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_))) {
                             let model_name = format!("{operation_name}Response{status}");
                             let model_types =
                                 parse_schema_to_model_type(&model_name, schema, all_schemas)?;
+                            inline_models.extend(model_types);
+                            model_name
+                        } else if matches!(
+                            schema_item.schema_kind,
+                            SchemaKind::Type(Type::Array(_))
+                        ) {
+                            is_array = true;
+                            let model_name = format!("{operation_name}ResponseArrayObject{status}");
+                            let model_types =
+                                parse_schema_to_model_type(&model_name, schema, all_schemas)?;
+
                             inline_models.extend(model_types);
                             model_name
                         } else {
@@ -245,11 +256,16 @@ fn process_operation(
                     } else {
                         extract_type_and_format(schema, all_schemas)?.0
                     };
+                    let schema = if is_array {
+                        format!("Vec<{}>", schema_type)
+                    } else {
+                        schema_type
+                    };
                     let response = ResponseModel {
                         name: operation_name,
-                        status_code: status.to_string(),
+                        status_code: format!("{}", status.to_string()),
                         content_type: content_type.clone(),
-                        schema: schema_type,
+                        schema: schema,
                         description: Some(response.description.clone()),
                     };
                     responses.push(response);
@@ -458,6 +474,16 @@ fn parse_schema_to_model_type(
 
                     match items {
                         ReferenceOr::Item(item_schema) => match &item_schema.schema_kind {
+                            SchemaKind::Type(Type::Object(_obj)) => {
+                                let array_model_schema = ReferenceOr::Item((**item_schema).clone());
+                                let array_object_models = parse_schema_to_model_type(
+                                    name,
+                                    &array_model_schema,
+                                    all_schemas,
+                                )?;
+                                models.extend(array_object_models);
+                            }
+
                             SchemaKind::OneOf { one_of } => {
                                 let item_type_name = format!("{array_name}Item");
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1161,11 +1161,9 @@ mod tests {
             assert_eq!(model.fields.len(), 2);
             assert_eq!(model.fields[0].name, "name");
             assert_eq!(model.fields[0].field_type, "String");
-            assert!(model.fields[0].is_required);
 
             assert_eq!(model.fields[1].name, "value");
             assert_eq!(model.fields[1].field_type, "i64");
-            assert!(!model.fields[1].is_required);
         } else {
             panic!("Expected a Struct model for GetItemResponse");
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -167,6 +167,7 @@ fn process_operation(
     backup_name: &str,
 ) -> Result<Vec<ModelType>> {
     let mut inline_models = Vec::new();
+    let operation_name = to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
 
     // Parse request body
     if let Some(request_body_ref) = &operation.request_body {
@@ -190,9 +191,6 @@ fn process_operation(
         if let Some((request_body, is_required)) = request_body_data {
             for (content_type, media_type) in &request_body.content {
                 if let Some(schema) = &media_type.schema {
-                    let operation_name =
-                        to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
-
                     let schema_type = if is_inline {
                         if let ReferenceOr::Item(schema_item) = schema {
                             if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_)))
@@ -229,8 +227,6 @@ fn process_operation(
         if let ReferenceOr::Item(response) = response_ref {
             for (content_type, media_type) in &response.content {
                 if let Some(schema) = &media_type.schema {
-                    let operation_name =
-                        to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
                     let mut is_array = false;
                     let schema_type = if let ReferenceOr::Item(schema_item) = schema {
                         if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_))) {
@@ -262,7 +258,7 @@ fn process_operation(
                         schema_type
                     };
                     let response = ResponseModel {
-                        name: operation_name,
+                        name: operation_name.clone(),
                         status_code: format!("{}", status),
                         content_type: content_type.clone(),
                         schema,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -357,7 +357,7 @@ fn parse_schema_to_model_type(
                                 inline_models.extend(nested_models);
                             }
                         }
-                        
+
                         let (field_info, inline_model) = match field_schema {
                             ReferenceOr::Item(boxed_schema) => extract_field_info(
                                 field_name,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -130,18 +130,23 @@ pub fn parse_openapi(
             ("PATCH", &path_item.patch),
         ];
 
-        for (method, op) in operations.iter().filter_map(|(m, o)| o.as_ref().map(|operation| (*m, operation))) {
+        for (method, op) in operations
+            .iter()
+            .filter_map(|(m, o)| o.as_ref().map(|operation| (*m, operation)))
+        {
             let backup_name = format!(
-                "{}{}", 
-                method, 
-                to_pascal_case(&path
-                    .replace('/', "-")
-                    .replace('{', "-")
-                    .replace('}', "")
-                )
+                "{}{}",
+                method,
+                to_pascal_case(&path.replace('/', "-").replace('{', "-").replace('}', ""))
             );
-            let inline_models =
-                process_operation(op, &mut requests, &mut responses, schemas, request_bodies, &backup_name)?;
+            let inline_models = process_operation(
+                op,
+                &mut requests,
+                &mut responses,
+                schemas,
+                request_bodies,
+                &backup_name,
+            )?;
             for model_type in inline_models {
                 if added_models.insert(model_type.name().to_string()) {
                     models.push(model_type);
@@ -159,7 +164,7 @@ fn process_operation(
     responses: &mut Vec<ResponseModel>,
     all_schemas: &IndexMap<String, ReferenceOr<Schema>>,
     request_bodies: &IndexMap<String, ReferenceOr<openapiv3::RequestBody>>,
-    backup_name: &str
+    backup_name: &str,
 ) -> Result<Vec<ModelType>> {
     let mut inline_models = Vec::new();
 
@@ -228,8 +233,7 @@ fn process_operation(
                         to_pascal_case(operation.operation_id.as_deref().unwrap_or(backup_name));
 
                     let schema_type = if let ReferenceOr::Item(schema_item) = schema {
-                        if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_)))
-                        {
+                        if matches!(schema_item.schema_kind, SchemaKind::Type(Type::Object(_))) {
                             let model_name = format!("{operation_name}Response{status}");
                             let model_types =
                                 parse_schema_to_model_type(&model_name, schema, all_schemas)?;
@@ -1112,8 +1116,8 @@ mod tests {
                 "/items": {
                     "get": {
                         "operationId": "getItem",
-                        "responses": { 
-                            "200": { 
+                        "responses": {
+                            "200": {
                                 "description": "OK",
                                 "content": {
                                     "application/json": {
@@ -1127,7 +1131,7 @@ mod tests {
                                         }
                                     }
                                 }
-                            } 
+                            }
                         }
                     }
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1134,6 +1134,74 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn test_parse_top_level_array_object_generates_model() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test API", "version": "1.0.0" },
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "getItems",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "exampleField": {
+                                                        "type": "string"
+                                                    },
+                                                    "anotherExampleField": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to deserialize OpenAPI spec");
+
+        let (models, _requests, responses) =
+            parse_openapi(&openapi_spec).expect("Failed to parse OpenAPI spec");
+
+        // 1. Verify that response model was created
+        assert_eq!(responses.len(), 1);
+        let response_model = &responses[0];
+        assert_eq!(response_model.name, "GetItems");
+
+        // 2. Verify that response schema references a Vec of the top level array object
+        assert_eq!(response_model.schema, "Vec<GetItemsResponseArrayObject200>");
+
+        // 3. Verify that the array object model was generated
+        let inline_model = models.iter().find(|m| m.name() == "GetItemsResponseArrayObject200");
+        assert!(
+            inline_model.is_some(),
+            "Expected a model named 'GetItemsResponseArrayObject200' to be generated"
+        );
+
+        if let Some(ModelType::Struct(model)) = inline_model {
+            assert_eq!(model.fields.len(), 2);
+            assert_eq!(model.fields[0].name, "anotherExampleField");
+            assert_eq!(model.fields[0].field_type, "String");
+
+            assert_eq!(model.fields[1].name, "exampleField");
+            assert_eq!(model.fields[1].field_type, "String");
+        } else {
+            panic!("Expected a Struct model for GetItemsResponse");
+        }
+    }
+
+    #[test]
     fn test_parse_inline_response_generates_model() {
         let openapi_spec: OpenAPI = serde_json::from_value(json!({
             "openapi": "3.0.0",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -329,6 +329,7 @@ fn parse_schema_to_model_type(
 
                     // Process regular properties
                     for (field_name, field_schema) in &obj.properties {
+                        let mut field_to_field_type: IndexMap<String, String> = IndexMap::new();
                         if let ReferenceOr::Item(boxed_schema) = field_schema {
                             if matches!(boxed_schema.schema_kind, SchemaKind::Type(Type::Object(_)))
                             {
@@ -340,9 +341,21 @@ fn parse_schema_to_model_type(
                                     all_schemas,
                                 )?;
                                 inline_models.extend(nested_models);
+                            } else if matches!(&boxed_schema.schema_kind, SchemaKind::Type(Type::Array(_))) {
+                                let struct_name = format!(
+                                    "{}Item",
+                                    to_pascal_case(field_name)
+                                );
+                                field_to_field_type.insert(field_name.to_string(), struct_name.to_string());
+                                let wrapped_schema = ReferenceOr::Item((**boxed_schema).clone());
+                                let nested_models = parse_schema_to_model_type(
+                                    &struct_name,
+                                    &wrapped_schema,
+                                    all_schemas,
+                                )?;
+                                inline_models.extend(nested_models);
                             }
                         }
-
                         let (field_info, inline_model) = match field_schema {
                             ReferenceOr::Item(boxed_schema) => extract_field_info(
                                 field_name,
@@ -363,7 +376,7 @@ fn parse_schema_to_model_type(
                         let is_required = obj.required.contains(field_name);
                         fields.push(Field {
                             name: field_name.clone(),
-                            field_type: field_info.field_type,
+                            field_type: field_to_field_type.get(field_name).unwrap_or(&field_info.field_type).to_string(),
                             format: field_info.format,
                             is_required,
                             is_array_ref: field_info.is_array_ref,
@@ -1132,6 +1145,79 @@ fn extract_fields_from_schema(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_parse_nested_object_array_generates_model() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test API", "version": "1.0.0" },
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "getItems",
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "exampleField": {
+                                                    "type": "string"
+                                                },
+                                                "objectArray": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "objectArrayItemField": {
+                                                                "type": "string"
+                                                            },
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to deserialize OpenAPI spec");
+
+        let (models, _requests, responses) =
+            parse_openapi(&openapi_spec).expect("Failed to parse OpenAPI spec");
+
+        // 1. Verify that response model was created
+        assert_eq!(responses.len(), 1);
+        let response_model = &responses[0];
+        assert_eq!(response_model.name, "GetItems");
+
+        // 2. Verify that response schema references the top level object
+        assert_eq!(response_model.schema, "GetItemsResponse200");
+
+        // 3. Verify that the nested object model was generated
+        let inline_model = models
+            .iter()
+            .find(|m| m.name() == "ObjectArrayItem");
+        assert!(
+            inline_model.is_some(),
+            "Expected a model named 'ObjectArrayItem' to be generated"
+        );
+
+        if let Some(ModelType::Struct(model)) = inline_model {
+            assert_eq!(model.fields.len(), 1);
+
+            assert_eq!(model.fields[0].name, "objectArrayItemField");
+            assert_eq!(model.fields[0].field_type, "String");
+        } else {
+            panic!("Expected a Struct model for GetItemsResponse");
+        }
+    }
 
     #[test]
     fn test_parse_top_level_array_object_generates_model() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -137,7 +137,7 @@ pub fn parse_openapi(
             let backup_name = format!(
                 "{}{}",
                 method,
-                to_pascal_case(&path.replace('/', "-").replace('{', "-").replace('}', ""))
+                to_pascal_case(&path.replace(['/', '{'], "-").replace('}', ""))
             );
             let inline_models = process_operation(
                 op,
@@ -263,9 +263,9 @@ fn process_operation(
                     };
                     let response = ResponseModel {
                         name: operation_name,
-                        status_code: format!("{}", status.to_string()),
+                        status_code: format!("{}", status),
                         content_type: content_type.clone(),
-                        schema: schema,
+                        schema,
                         description: Some(response.description.clone()),
                     };
                     responses.push(response);
@@ -1183,7 +1183,9 @@ mod tests {
         assert_eq!(response_model.schema, "Vec<GetItemsResponseArrayObject200>");
 
         // 3. Verify that the array object model was generated
-        let inline_model = models.iter().find(|m| m.name() == "GetItemsResponseArrayObject200");
+        let inline_model = models
+            .iter()
+            .find(|m| m.name() == "GetItemsResponseArrayObject200");
         assert!(
             inline_model.is_some(),
             "Expected a model named 'GetItemsResponseArrayObject200' to be generated"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -341,12 +341,13 @@ fn parse_schema_to_model_type(
                                     all_schemas,
                                 )?;
                                 inline_models.extend(nested_models);
-                            } else if matches!(&boxed_schema.schema_kind, SchemaKind::Type(Type::Array(_))) {
-                                let struct_name = format!(
-                                    "{}Item",
-                                    to_pascal_case(field_name)
-                                );
-                                field_to_field_type.insert(field_name.to_string(), struct_name.to_string());
+                            } else if matches!(
+                                &boxed_schema.schema_kind,
+                                SchemaKind::Type(Type::Array(_))
+                            ) {
+                                let struct_name = format!("{}Item", to_pascal_case(field_name));
+                                field_to_field_type
+                                    .insert(field_name.to_string(), struct_name.to_string());
                                 let wrapped_schema = ReferenceOr::Item((**boxed_schema).clone());
                                 let nested_models = parse_schema_to_model_type(
                                     &struct_name,
@@ -376,7 +377,10 @@ fn parse_schema_to_model_type(
                         let is_required = obj.required.contains(field_name);
                         fields.push(Field {
                             name: field_name.clone(),
-                            field_type: field_to_field_type.get(field_name).unwrap_or(&field_info.field_type).to_string(),
+                            field_type: field_to_field_type
+                                .get(field_name)
+                                .unwrap_or(&field_info.field_type)
+                                .to_string(),
                             format: field_info.format,
                             is_required,
                             is_array_ref: field_info.is_array_ref,
@@ -1201,9 +1205,7 @@ mod tests {
         assert_eq!(response_model.schema, "GetItemsResponse200");
 
         // 3. Verify that the nested object model was generated
-        let inline_model = models
-            .iter()
-            .find(|m| m.name() == "ObjectArrayItem");
+        let inline_model = models.iter().find(|m| m.name() == "ObjectArrayItem");
         assert!(
             inline_model.is_some(),
             "Expected a model named 'ObjectArrayItem' to be generated"


### PR DESCRIPTION
I ran the cli on an API spec and it didn't generate anything. This spec had responses but no request bodies or other schemas. Also, the operations didn't have `operation_id`s. 

I still wanted to generate models from these, so I made a couple changes:
- Fix models from inline responses not getting added to `inline_models`
- Add `backup_name` to uniquely specify operations with no `operation_id`

I can add tests and/or split into different PRs, but first I wanted to see of you were interested in either of these changes.