### PR TITLE
fix: set up default derives

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -294,7 +294,7 @@ fn generate_request_model(request: &RequestModel) -> Result<String> {
     }
 
     output.push_str(&format!("/// {}\n", request.name));
-    output.push_str("#[derive(Debug, Clone, Serialize)]\n");
+    output.push_str("#[derive(Debug, Clone, Deserialize)]\n");
     output.push_str(&format!("pub struct {} {{\n", request.name));
     output.push_str(&format!("    pub body: {},\n", request.schema));
     output.push_str("}\n");
@@ -316,7 +316,7 @@ fn generate_response_model(response: &ResponseModel) -> Result<String> {
         "",
     ));
 
-    output.push_str("#[derive(Debug, Clone, Deserialize)]\n");
+    output.push_str("#[derive(Debug, Clone, Serialize)]\n");
     output.push_str(&format!("pub struct {type_name} {{\n"));
     output.push_str(&format!("    pub body: {},\n", response.schema));
     output.push_str("}\n");


### PR DESCRIPTION
Swap default derives for requests and responses structs:
 - `*Request`: Serialize -> Deserialize
 - `*Response`: Deserialize -> Serialize