### PR TITLE
feat!: make possible to omit some types of output structs

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -14,6 +14,27 @@ bitflags::bitflags! {
         const DATETIME = 0b00000010;
         const DATE = 0b00000100;
     }
+
+    /// Choose what type of structs you want to generate:
+    ///  - Models (generated always)
+    ///  - Requests (optional)
+    ///  - Responses (optional)
+    pub struct GenerateMode: u8 {
+        /// Models will be always include to output
+        const MODELS = 0;
+        /// Additional includes request structs to output
+        const REQUESTS = 1 << 0;
+        /// Additional includes response structs to output
+        const RESPONSES = 1 << 1;
+        /// Outputs all possible structs: models, request and response structs
+        const ALL = Self::REQUESTS.bits() | Self::RESPONSES.bits();
+    }
+}
+
+impl Default for GenerateMode {
+    fn default() -> Self {
+        Self::ALL
+    }
 }
 
 static HDR: OnceLock<String> = OnceLock::new();
@@ -138,6 +159,7 @@ pub fn generate_models(
     models: &[ModelType],
     requests: &[RequestModel],
     responses: &[ResponseModel],
+    mode: GenerateMode,
 ) -> Result<String> {
     // First, generate all model code to determine which imports are needed
     let mut models_code = String::new();
@@ -163,12 +185,16 @@ pub fn generate_models(
         }
     }
 
-    for request in requests {
-        models_code.push_str(&generate_request_model(request)?);
+    if mode.contains(GenerateMode::REQUESTS) {
+        for request in requests {
+            models_code.push_str(&generate_request_model(request)?);
+        }
     }
 
-    for response in responses {
-        models_code.push_str(&generate_response_model(response)?);
+    if mode.contains(GenerateMode::RESPONSES) {
+        for response in responses {
+            models_code.push_str(&generate_response_model(response)?);
+        }
     }
 
     // Determine which imports are actually needed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod models;
 pub mod parser;
 
 pub use error::Error;
-pub use generator::generate_models;
+pub use generator::{generate_models, GenerateMode};
 pub use parser::parse_openapi;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use openapi_model_generator::{cli::Args, generator, parser, Error, Result};
+use openapi_model_generator::{cli::Args, generator, parser, Error, GenerateMode, Result};
 use openapiv3::OpenAPI;
 use std::fs;
 use std::io;
@@ -73,7 +73,8 @@ fn main() -> Result<()> {
 
     let (models, requests, responses) = parser::parse_openapi(&openapi)?;
 
-    let rust_code = generator::generate_models(&models, &requests, &responses)?;
+    let rust_code =
+        generator::generate_models(&models, &requests, &responses, GenerateMode::default())?;
     let output_models_path = args.output.join("models.rs");
     fs::write(&output_models_path, rust_code.trim())?;
 


### PR DESCRIPTION
This changes make possible to choose what type of generated structs we want to get.

In the output we generating three different types:
 - Models (generate always)
 - Request structs (now we can omit this)
 - Response structs (now we can omit this)

(!) This is a BREAKING CHANGE commit.
