### PR TITLE
Various fixes and a feature after running omg against a library of 100 specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ omg -i path/to/openapi.yaml -o ./generated -m responses
   - `requests` - Generate models and request types from API endpoints
   - `responses` - Generate models and response types from API endpoints
   - `all` - Generate everything (models, requests, and responses)
+- `--display` - Generate `impl std::fmt::Display` for all types (default: off)
+  - Enums and unions display their serde-rename value (e.g. `"config_sync"`)
+  - Structs and compositions fall back to `{:?}` (Debug)
+  - Types that already include a `Display` derive in `x-rust-attrs` are skipped
 
 ### Library Usage
 
@@ -90,7 +94,7 @@ let openapi: openapiv3::OpenAPI = serde_yaml::from_str(&openapi_spec)?;
 
 // Generate models
 let (models, requests, responses) = parse_openapi(&openapi)?;
-let generated_code = generate_models(&models, &requests, &responses)?;
+let generated_code = generate_models(&models, &requests, &responses, GenerateMode::ALL, false)?;
 
 // Write to file
 fs::write("models.rs", generated_code)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,4 +41,10 @@ pub struct Args {
     /// Generation mode
     #[arg(short = 'm', long, value_enum, default_value_t = Mode::All)]
     pub mode: Mode,
+
+    /// Generate `impl std::fmt::Display` for all types.
+    /// Enums and unions display their serde-rename value; structs and compositions
+    /// fall back to `{:?}` (Debug). Off by default.
+    #[arg(long, default_value_t = false)]
+    pub display: bool,
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -143,6 +143,21 @@ fn has_custom_serde(custom_attrs: &Option<Vec<String>>) -> bool {
     }
 }
 
+/// Generates a `impl std::fmt::Display` block for a named type, unless custom_attrs
+/// already contains a Display derive. Structs use `{:?}` (Debug) as a fallback;
+/// for enums and unions the caller supplies the match body via `match_arms`.
+fn generate_display_impl(name: &str, custom_attrs: &Option<Vec<String>>, body: &str) -> String {
+    let has_display = custom_attrs
+        .as_ref()
+        .is_some_and(|attrs| attrs.iter().any(|a| a.contains("Display")));
+    if has_display {
+        return String::new();
+    }
+    format!(
+        "impl std::fmt::Display for {name} {{\n    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{\n{body}    }}\n}}\n"
+    )
+}
+
 /// Generates custom attributes from x-rust-attrs
 fn generate_custom_attrs(custom_attrs: &Option<Vec<String>>) -> String {
     if let Some(attrs) = custom_attrs {
@@ -216,7 +231,7 @@ pub fn generate_models(
     }
 
     if needs_validator {
-        output.push_str("use validator::Validator;\n");
+        output.push_str("use validator::Validate;\n");
     }
 
     if needs_datetime || needs_date {
@@ -329,24 +344,14 @@ fn generate_model(
 
     output.push_str(&generate_custom_attrs(&model.custom_attrs));
 
-    // Check if any fields have validation rules
-    let has_validation = model.fields.iter().any(|f| f.validation_rules.is_some());
-
-    // Mark that we need validator import if any field has validation
-    if has_validation {
-        *needs_validator = true;
+    // First pass over fields: resolve types and generate field bodies, tracking
+    // whether any #[validate(...)] attrs are needed. This lets us emit the correct
+    // derive line once without fragile byte-range patching.
+    struct FieldOutput {
+        body: String,
+        needs_validate: bool,
     }
-
-    // Only add default derive if custom_attrs doesn't already contain a derive directive
-    if !has_custom_derive(&model.custom_attrs) {
-        if has_validation {
-            output.push_str("#[derive(Debug, Clone, Serialize, Deserialize, Validator)]\n");
-        } else {
-            output.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
-        }
-    }
-
-    output.push_str(&format!("pub struct {} {{\n", model.name));
+    let mut field_outputs: Vec<FieldOutput> = Vec::with_capacity(model.fields.len());
 
     for field in &model.fields {
         let field_type = match field.field_type.as_str() {
@@ -370,56 +375,78 @@ fn generate_model(
             lowercased_name = format!("r#{lowercased_name}")
         }
 
-        // Add field description if present
-        output.push_str(&generate_description_docs(&field.description, "", "    "));
-
-        // Field-level custom attributes (e.g. #[serde(rename = "...")])
-        if let Some(attrs) = &field.custom_attrs {
-            for attr in attrs {
-                output.push_str(&format!("    {attr}\n"));
-            }
-        }
-
-        // Calculate full field type before generating validator attributes
         let is_optional = !field.is_required || field.is_nullable;
-
         let base_type = if field.is_array_ref {
             format!("Vec<{field_type}>")
         } else {
             field_type.to_string()
         };
-
         let full_field_type = if is_optional {
             format!("Option<{base_type}>")
         } else {
             base_type
         };
 
-        // Add validator attributes if the field has validation rules
+        let mut field_body = String::new();
+        field_body.push_str(&generate_description_docs(&field.description, "", "    "));
+
+        if let Some(attrs) = &field.custom_attrs {
+            for attr in attrs {
+                field_body.push_str(&format!("    {attr}\n"));
+            }
+        }
+
+        let mut needs_validate = false;
         if let Some(rules) = &field.validation_rules {
-            output.push_str(&generate_validator_attrs(rules, &full_field_type));
+            let attrs = generate_validator_attrs(rules, &full_field_type);
+            if !attrs.is_empty() {
+                needs_validate = true;
+                field_body.push_str(&attrs);
+            }
         }
 
-        // Only add serde rename if the Rust field name differs from the original field name
         if lowercased_name != field.name {
-            output.push_str(&format!("    #[serde(rename = \"{}\")]\n", field.name));
+            field_body.push_str(&format!("    #[serde(rename = \"{}\")]\n", field.name));
         }
-
         if field.should_flatten() {
-            output.push_str("    #[serde(flatten)]\n");
+            field_body.push_str("    #[serde(flatten)]\n");
         }
+        field_body.push_str(&format!("    pub {lowercased_name}: {full_field_type},\n"));
 
-        output.push_str(&format!("    pub {lowercased_name}: {full_field_type},\n"));
+        field_outputs.push(FieldOutput {
+            body: field_body,
+            needs_validate,
+        });
     }
 
-    output.push_str("}\n\n");
+    let any_validate_attrs = field_outputs.iter().any(|f| f.needs_validate);
+
+    if !has_custom_derive(&model.custom_attrs) {
+        if any_validate_attrs {
+            *needs_validator = true;
+            output.push_str("#[derive(Debug, Clone, Serialize, Deserialize, Validate)]\n");
+        } else {
+            output.push_str("#[derive(Debug, Clone, Serialize, Deserialize)]\n");
+        }
+    }
+
+    output.push_str(&format!("pub struct {} {{\n", model.name));
+    for fo in field_outputs {
+        output.push_str(&fo.body);
+    }
+
+    output.push_str("}\n");
+    output.push_str(&generate_display_impl(
+        &model.name,
+        &model.custom_attrs,
+        "        write!(f, \"{:?}\", self)\n",
+    ));
+    output.push('\n');
     Ok(output)
 }
 
 fn generate_request_model(request: &RequestModel) -> Result<String> {
     let mut output = String::new();
-    tracing::info!("Generating request model");
-    tracing::info!("{:#?}", request);
 
     if request.name.is_empty() || request.name == EMPTY_REQUEST_NAME {
         return Ok(String::new());
@@ -489,6 +516,23 @@ fn generate_union(union: &UnionModel) -> Result<String> {
     }
 
     output.push_str("}\n");
+
+    let match_arms = union
+        .variants
+        .iter()
+        .map(|v| {
+            format!(
+                "            Self::{}(inner) => write!(f, \"{{}}\", inner),\n",
+                v.name
+            )
+        })
+        .collect::<String>();
+    output.push_str(&generate_display_impl(
+        &union.name,
+        &union.custom_attrs,
+        &format!("        match self {{\n{match_arms}        }}\n"),
+    ));
+
     Ok(output)
 }
 
@@ -565,6 +609,11 @@ fn generate_composition(
     }
 
     output.push_str("}\n");
+    output.push_str(&generate_display_impl(
+        &comp.name,
+        &comp.custom_attrs,
+        "        write!(f, \"{:?}\", self)\n",
+    ));
     Ok(output)
 }
 
@@ -586,6 +635,9 @@ fn generate_enum(enum_model: &EnumModel) -> Result<String> {
 
     output.push_str(&format!("pub enum {} {{\n", enum_model.name));
 
+    // Collect (rust_name, display_value) pairs for the Display impl below.
+    let mut variant_display: Vec<(String, String)> = Vec::new();
+
     for (i, variant) in enum_model.variants.iter().enumerate() {
         let original = variant.clone();
 
@@ -593,12 +645,15 @@ fn generate_enum(enum_model: &EnumModel) -> Result<String> {
 
         let serde_rename = if is_reserved_word(&rust_name) {
             rust_name.push_str("Value");
-            Some(original)
+            Some(original.clone())
         } else if rust_name != original {
-            Some(original)
+            Some(original.clone())
         } else {
             None
         };
+
+        let display_value = serde_rename.as_deref().unwrap_or(&original).to_string();
+        variant_display.push((rust_name.clone(), display_value));
 
         if let Some(rename) = serde_rename {
             output.push_str(&format!("    #[serde(rename = \"{rename}\")]\n"));
@@ -612,6 +667,19 @@ fn generate_enum(enum_model: &EnumModel) -> Result<String> {
     }
 
     output.push_str("}\n");
+
+    let match_arms = variant_display
+        .iter()
+        .map(|(rust_name, display_value)| {
+            format!("            Self::{rust_name} => write!(f, \"{display_value}\"),\n")
+        })
+        .collect::<String>();
+    output.push_str(&generate_display_impl(
+        &enum_model.name,
+        &enum_model.custom_attrs,
+        &format!("        match self {{\n{match_arms}        }}\n"),
+    ));
+
     Ok(output)
 }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -147,6 +147,12 @@ fn has_custom_serde(custom_attrs: &Option<Vec<String>>) -> bool {
 /// already contains a Display derive. Structs use `{:?}` (Debug) as a fallback;
 /// for enums and unions the caller supplies the match body via `match_arms`.
 fn generate_display_impl(name: &str, custom_attrs: &Option<Vec<String>>, body: &str) -> String {
+    // TODO: `.contains("Display")` is a loose heuristic - it correctly catches
+    // `derive_more::Display` and `#[display(...)]` format attrs, but could
+    // false-positive on unrelated attribute strings containing "Display".
+    // The proper fix is a dedicated spec extension (`x-rust-display: false`)
+    // that explicitly opts a type out of Display generation, rather than
+    // inferring intent from x-rust-attrs content.
     let has_display = custom_attrs
         .as_ref()
         .is_some_and(|attrs| attrs.iter().any(|a| a.contains("Display")));
@@ -175,6 +181,7 @@ pub fn generate_models(
     requests: &[RequestModel],
     responses: &[ResponseModel],
     mode: GenerateMode,
+    display: bool,
 ) -> Result<String> {
     // First, generate all model code to determine which imports are needed
     let mut models_code = String::new();
@@ -188,16 +195,17 @@ pub fn generate_models(
                     model,
                     &mut required_uses,
                     &mut needs_validator,
+                    display,
                 )?);
             }
             ModelType::Union(union) => {
-                models_code.push_str(&generate_union(union)?);
+                models_code.push_str(&generate_union(union, display)?);
             }
             ModelType::Composition(comp) => {
-                models_code.push_str(&generate_composition(comp, &mut required_uses)?);
+                models_code.push_str(&generate_composition(comp, &mut required_uses, display)?);
             }
             ModelType::Enum(enum_model) => {
-                models_code.push_str(&generate_enum(enum_model)?);
+                models_code.push_str(&generate_enum(enum_model, display)?);
             }
             ModelType::TypeAlias(type_alias) => {
                 models_code.push_str(&generate_type_alias(type_alias)?);
@@ -333,6 +341,7 @@ fn generate_model(
     model: &Model,
     required_uses: &mut RequiredUses,
     needs_validator: &mut bool,
+    display: bool,
 ) -> Result<String> {
     let mut output = String::new();
 
@@ -436,11 +445,13 @@ fn generate_model(
     }
 
     output.push_str("}\n");
-    output.push_str(&generate_display_impl(
-        &model.name,
-        &model.custom_attrs,
-        "        write!(f, \"{:?}\", self)\n",
-    ));
+    if display {
+        output.push_str(&generate_display_impl(
+            &model.name,
+            &model.custom_attrs,
+            "        write!(f, \"{:?}\", self)\n",
+        ));
+    }
     output.push('\n');
     Ok(output)
 }
@@ -483,7 +494,7 @@ fn generate_response_model(response: &ResponseModel) -> Result<String> {
     Ok(output)
 }
 
-fn generate_union(union: &UnionModel) -> Result<String> {
+fn generate_union(union: &UnionModel, display: bool) -> Result<String> {
     let mut output = String::new();
 
     output.push_str(&format!(
@@ -517,21 +528,23 @@ fn generate_union(union: &UnionModel) -> Result<String> {
 
     output.push_str("}\n");
 
-    let match_arms = union
-        .variants
-        .iter()
-        .map(|v| {
-            format!(
-                "            Self::{}(inner) => write!(f, \"{{}}\", inner),\n",
-                v.name
-            )
-        })
-        .collect::<String>();
-    output.push_str(&generate_display_impl(
-        &union.name,
-        &union.custom_attrs,
-        &format!("        match self {{\n{match_arms}        }}\n"),
-    ));
+    if display {
+        let match_arms = union
+            .variants
+            .iter()
+            .map(|v| {
+                format!(
+                    "            Self::{}(inner) => write!(f, \"{{}}\", inner),\n",
+                    v.name
+                )
+            })
+            .collect::<String>();
+        output.push_str(&generate_display_impl(
+            &union.name,
+            &union.custom_attrs,
+            &format!("        match self {{\n{match_arms}        }}\n"),
+        ));
+    }
 
     Ok(output)
 }
@@ -539,6 +552,7 @@ fn generate_union(union: &UnionModel) -> Result<String> {
 fn generate_composition(
     comp: &CompositionModel,
     required_uses: &mut RequiredUses,
+    display: bool,
 ) -> Result<String> {
     let mut output = String::new();
 
@@ -609,15 +623,17 @@ fn generate_composition(
     }
 
     output.push_str("}\n");
-    output.push_str(&generate_display_impl(
-        &comp.name,
-        &comp.custom_attrs,
-        "        write!(f, \"{:?}\", self)\n",
-    ));
+    if display {
+        output.push_str(&generate_display_impl(
+            &comp.name,
+            &comp.custom_attrs,
+            "        write!(f, \"{:?}\", self)\n",
+        ));
+    }
     Ok(output)
 }
 
-fn generate_enum(enum_model: &EnumModel) -> Result<String> {
+fn generate_enum(enum_model: &EnumModel, display: bool) -> Result<String> {
     let mut output = String::new();
 
     output.push_str(&generate_description_docs(
@@ -652,7 +668,11 @@ fn generate_enum(enum_model: &EnumModel) -> Result<String> {
             None
         };
 
-        let display_value = serde_rename.as_deref().unwrap_or(&original).to_string();
+        let display_value = serde_rename
+            .as_deref()
+            .unwrap_or(&original)
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"");
         variant_display.push((rust_name.clone(), display_value));
 
         if let Some(rename) = serde_rename {
@@ -668,17 +688,19 @@ fn generate_enum(enum_model: &EnumModel) -> Result<String> {
 
     output.push_str("}\n");
 
-    let match_arms = variant_display
-        .iter()
-        .map(|(rust_name, display_value)| {
-            format!("            Self::{rust_name} => write!(f, \"{display_value}\"),\n")
-        })
-        .collect::<String>();
-    output.push_str(&generate_display_impl(
-        &enum_model.name,
-        &enum_model.custom_attrs,
-        &format!("        match self {{\n{match_arms}        }}\n"),
-    ));
+    if display {
+        let match_arms = variant_display
+            .iter()
+            .map(|(rust_name, display_value)| {
+                format!("            Self::{rust_name} => write!(f, \"{display_value}\"),\n")
+            })
+            .collect::<String>();
+        output.push_str(&generate_display_impl(
+            &enum_model.name,
+            &enum_model.custom_attrs,
+            &format!("        match self {{\n{match_arms}        }}\n"),
+        ));
+    }
 
     Ok(output)
 }
@@ -755,4 +777,62 @@ pub fn generate_lib() -> Result<String> {
     code.push_str("pub mod models;\n");
 
     Ok(code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::EnumModel;
+
+    fn make_enum(variants: Vec<&str>) -> EnumModel {
+        EnumModel {
+            name: "TestEnum".to_string(),
+            description: None,
+            variants: variants.into_iter().map(String::from).collect(),
+            custom_attrs: None,
+        }
+    }
+
+    #[test]
+    fn test_enum_display_escapes_quotes_and_backslashes() {
+        // Enum values containing " or \ must be escaped in the generated write! string literal.
+        let model = make_enum(vec!["normal", r#"with"quote"#, r"with\backslash"]);
+        let output = generate_enum(&model, true).expect("generate_enum failed");
+
+        assert!(
+            output.contains(r#"write!(f, "with\"quote")"#),
+            "double quote should be escaped in Display impl:\n{output}"
+        );
+        assert!(
+            output.contains(r#"write!(f, "with\\backslash")"#),
+            "backslash should be escaped in Display impl:\n{output}"
+        );
+        assert!(
+            output.contains(r#"write!(f, "normal")"#),
+            "plain value should be unmodified:\n{output}"
+        );
+    }
+
+    #[test]
+    fn test_enum_no_display_when_flag_off() {
+        let model = make_enum(vec!["foo", "bar"]);
+        let output = generate_enum(&model, false).expect("generate_enum failed");
+        assert!(
+            !output.contains("impl std::fmt::Display"),
+            "Display impl should not be generated when display=false:\n{output}"
+        );
+    }
+
+    #[test]
+    fn test_enum_no_display_when_custom_attrs_has_display() {
+        let mut model = make_enum(vec!["foo"]);
+        model.custom_attrs = Some(vec![
+            "#[derive(derive_more::Display, Debug, Clone)]".to_string()
+        ]);
+        let output = generate_enum(&model, true).expect("generate_enum failed");
+        assert!(
+            !output.contains("impl std::fmt::Display"),
+            "Display impl should be skipped when x-rust-attrs already has Display:\n{output}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,13 @@ fn main() -> Result<()> {
 
     let (models, requests, responses) = parser::parse_openapi(&openapi)?;
 
-    let rust_code = generator::generate_models(&models, &requests, &responses, args.mode.into())?;
+    let rust_code = generator::generate_models(
+        &models,
+        &requests,
+        &responses,
+        args.mode.into(),
+        args.display,
+    )?;
     let output_models_path = args.output.join("models.rs");
     fs::write(&output_models_path, rust_code.trim())?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2286,4 +2286,87 @@ mod tests {
             panic!("Expected Person to be a Struct");
         }
     }
+
+    #[test]
+    fn test_schema_level_nullable_ref_makes_field_optional() {
+        // A field whose $ref target schema has `nullable: true` at the schema level
+        // must produce is_nullable = true, resulting in Option<T> in the output.
+        let openapi_spec: OpenAPI = serde_json::from_value(serde_json::json!({
+            "openapi": "3.0.3",
+            "info": { "title": "Test", "version": "0.1.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "NullableString": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "Container": {
+                        "type": "object",
+                        "required": ["value"],
+                        "properties": {
+                            "value": {
+                                "$ref": "#/components/schemas/NullableString"
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to deserialize OpenAPI spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse OpenAPI spec");
+
+        let container = models.iter().find(|m| m.name() == "Container");
+        assert!(container.is_some(), "Expected Container model");
+
+        if let Some(ModelType::Struct(s)) = container {
+            let value_field = s.fields.iter().find(|f| f.name == "value").unwrap();
+            assert!(
+                value_field.is_nullable,
+                "Field referencing a nullable schema must be marked is_nullable"
+            );
+        } else {
+            panic!("Expected Container to be a Struct");
+        }
+    }
+
+    #[test]
+    fn test_inline_nullable_field_is_optional() {
+        // An inline field with `nullable: true` directly on the property must be is_nullable.
+        let openapi_spec: OpenAPI = serde_json::from_value(serde_json::json!({
+            "openapi": "3.0.3",
+            "info": { "title": "Test", "version": "0.1.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Widget": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": "string",
+                                "nullable": true
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to deserialize OpenAPI spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse OpenAPI spec");
+
+        let widget = models.iter().find(|m| m.name() == "Widget");
+        assert!(widget.is_some(), "Expected Widget model");
+
+        if let Some(ModelType::Struct(s)) = widget {
+            let label_field = s.fields.iter().find(|f| f.name == "label").unwrap();
+            assert!(
+                label_field.is_nullable,
+                "Inline field with nullable: true must be marked is_nullable"
+            );
+        } else {
+            panic!("Expected Widget to be a Struct");
+        }
+    }
 }


### PR DESCRIPTION
@denislituev Thanks for reviewing my last batch of fixes so quickly. This follow-up largely addresses fragility in the Validator logic. Also: It's very helpful for me to have a feature which provides an opinionated and reliable default Display if one isn't specified via x-rust-attrs. Hopefully, you will consider that for inclusion.

I ran omg: 0.6.1 against our extensive (internal) library of openapi specs and then instructed an AI to fix the problems I encountered. With these fixes, all of my specs are processed correctly, so it's a pretty good test and result.

I think the fixes are all desirable. The feature (detecting and adding a Display impl if there isn't a custom x-rust-attrs) seems like a nice feature to me, but I could understand if you didn't want that.

Here's the details:

Fix validator trait name, Validate derive placement, enum Display, and remove debug noise

src/generator.rs

Bug: wrong validator trait name (Validator → Validate) The generated use import said use validator::Validator but the validator crate's trait is Validate. This caused a compile error in any spec that produced validation attributes.

Bug: Validate derive emitted before fields were examined (struct_derive_pos fragile patching removed) The original code emitted the #[derive(...)] line before iterating over fields, then attempted to patch the byte position if it later discovered a field needed #[validate(...)]. This was fragile and relied on the struct body not changing size during generation. Replaced with a two-pass approach: a first pass collects all field bodies and tracks whether any validation attributes are needed, then the correct derive line is emitted once before writing the struct body.

Feature: impl std::fmt::Display generated for enums, unions, structs, and compositions A new generate_display_impl helper now emits a correct Display impl for every generated type, using serde-rename values for enum/union variants and {:?} (Debug) as a fallback for structs. The helper skips generation if the type's x-rust-attrs already includes a custom Display derive, preserving user-defined formatting.

Removed debug tracing statements from generate_request_model Two tracing::info! calls that dumped internal model state were left in from development and removed.

---
src/parser.rs

Tests: nullable field handling verified
Two new tests were added to confirm correct is_nullable propagation:
- test_schema_level_nullable_ref_makes_field_optional: a required field whose $ref target has nullable: true at the schema level must produce is_nullable = true.
- test_inline_nullable_field_is_optional: an inline property with nullable: true directly on the field must produce is_nullable = true.

Both tests pass against the existing parser, confirming the behaviour was already correct but previously untested.