### PR TITLE
Tests: unit and integration (coverage > 80%)

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1070,7 +1070,7 @@ mod tests {
             max_length: Some(100),
             ..Default::default()
         };
-        let out = generate_validator_attrs(&rules, "String");
+        let out = generate_validator_attrs(&rules, "String", &mut IndexMap::new());
         assert!(out.contains("#[validate(length("));
         assert!(out.contains("min = 1"));
         assert!(out.contains("max = 100"));
@@ -1083,7 +1083,7 @@ mod tests {
             email: true,
             ..Default::default()
         };
-        let out = generate_validator_attrs(&rules, "String");
+        let out = generate_validator_attrs(&rules, "String", &mut IndexMap::new());
         assert!(out.contains("#[validate(email)]\n"));
     }
 
@@ -1094,7 +1094,7 @@ mod tests {
             url: true,
             ..Default::default()
         };
-        let out = generate_validator_attrs(&rules, "Option<String>");
+        let out = generate_validator_attrs(&rules, "Option<String>", &mut IndexMap::new());
         assert!(out.contains("#[validate(url)]\n"));
     }
 
@@ -1105,8 +1105,10 @@ mod tests {
             pattern: Some(r"^\d+$".to_string()),
             ..Default::default()
         };
-        let out = generate_validator_attrs(&rules, "String");
-        assert!(out.contains("#[regex(pattern = r\""));
+        let mut registry = IndexMap::new();
+        let out = generate_validator_attrs(&rules, "String", &mut registry);
+        assert!(out.contains("#[validate(regex(path = RE_1))]\n"));
+        assert!(registry.contains_key(r"^\d+$"));
     }
 
     #[test]
@@ -1117,7 +1119,7 @@ mod tests {
             maximum: Some(255.0),
             ..Default::default()
         };
-        let out = generate_validator_attrs(&rules, "i64");
+        let out = generate_validator_attrs(&rules, "i64", &mut IndexMap::new());
         assert!(out.contains("#[validate(range("));
         assert!(out.contains("min = 0"));
         assert!(out.contains("max = 255"));
@@ -1131,7 +1133,7 @@ mod tests {
             max_items: Some(10),
             ..Default::default()
         };
-        let out = generate_validator_attrs(&rules, "Vec<String>");
+        let out = generate_validator_attrs(&rules, "Vec<String>", &mut IndexMap::new());
         assert!(out.contains("#[validate(length("));
         assert!(out.contains("min = 1"));
         assert!(out.contains("max = 10"));
@@ -1145,8 +1147,101 @@ mod tests {
             ..Default::default()
         };
         // Custom type that doesn't match any arm → no output
-        let out = generate_validator_attrs(&rules, "MyCustomType");
+        let out = generate_validator_attrs(&rules, "MyCustomType", &mut IndexMap::new());
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_f64_range_uses_float_literals() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            minimum: Some(0.0),
+            maximum: Some(1.0),
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "f64", &mut IndexMap::new());
+        assert!(out.contains("#[validate(range("));
+        // Must use float literals (0.0, 1.0) not integer literals (0, 1)
+        assert!(out.contains("min = 0.0"), "expected float literal 'min = 0.0', got:\n{out}");
+        assert!(out.contains("max = 1.0"), "expected float literal 'max = 1.0', got:\n{out}");
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_f32_range_uses_float_literals() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            minimum: Some(0.5),
+            maximum: Some(100.5),
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "f32", &mut IndexMap::new());
+        assert!(out.contains("#[validate(range("));
+        assert!(out.contains("min = 0.5"), "expected 'min = 0.5', got:\n{out}");
+        assert!(out.contains("max = 100.5"), "expected 'max = 100.5', got:\n{out}");
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_f64_integer_value_uses_dot_zero() {
+        // Integer-valued f64 bounds must still emit float literals (e.g. 0.0 not 0)
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            minimum: Some(5.0),
+            maximum: Some(255.0),
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "f64", &mut IndexMap::new());
+        assert!(out.contains("min = 5.0"), "expected 'min = 5.0', got:\n{out}");
+        assert!(out.contains("max = 255.0"), "expected 'max = 255.0', got:\n{out}");
+        // Ensure integer literals are NOT present
+        assert!(!out.contains("min = 5,") && !out.contains("min = 5)"),
+            "integer literal found in float range attr:\n{out}");
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_pattern_emits_regex_path() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            pattern: Some(r"^[a-z]+$".to_string()),
+            ..Default::default()
+        };
+        let mut registry = IndexMap::new();
+        let out = generate_validator_attrs(&rules, "String", &mut registry);
+        // Must emit validate(regex(path = RE_N)) not #[regex(pattern = ...)]
+        assert!(out.contains("#[validate(regex(path = RE_1))]"),
+            "expected regex(path = RE_1), got:\n{out}");
+        assert_eq!(registry.len(), 1);
+        assert_eq!(registry.get(r"^[a-z]+$"), Some(&"RE_1".to_string()));
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_identical_patterns_deduplicated() {
+        use crate::models::ValidationRules;
+        let pattern = r"^\d{3}$".to_string();
+        let rules = ValidationRules {
+            pattern: Some(pattern.clone()),
+            ..Default::default()
+        };
+        let mut registry = IndexMap::new();
+        // First field registers RE_1
+        let out1 = generate_validator_attrs(&rules, "String", &mut registry);
+        // Second field with same pattern reuses RE_1
+        let out2 = generate_validator_attrs(&rules, "String", &mut registry);
+        assert!(out1.contains("RE_1"));
+        assert!(out2.contains("RE_1"), "identical pattern should reuse RE_1, got:\n{out2}");
+        assert_eq!(registry.len(), 1, "duplicate pattern must not add a second entry");
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_distinct_patterns_get_separate_statics() {
+        use crate::models::ValidationRules;
+        let mut registry = IndexMap::new();
+        let rules1 = ValidationRules { pattern: Some(r"^a+$".to_string()), ..Default::default() };
+        let rules2 = ValidationRules { pattern: Some(r"^b+$".to_string()), ..Default::default() };
+        let out1 = generate_validator_attrs(&rules1, "String", &mut registry);
+        let out2 = generate_validator_attrs(&rules2, "String", &mut registry);
+        assert!(out1.contains("RE_1"));
+        assert!(out2.contains("RE_2"));
+        assert_eq!(registry.len(), 2);
     }
 
     // ─── generate_model ──────────────────────────────────────────────────────
@@ -1185,7 +1280,7 @@ mod tests {
         );
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(out.contains("pub struct User {"));
         assert!(out.contains("pub id: String,"));
         assert!(out.contains("pub age: Option<i64>,"));
@@ -1198,7 +1293,7 @@ mod tests {
         let model = make_model("Product", vec![make_field("name", "String", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, true).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), true).expect("generate_model failed");
         assert!(out.contains("impl std::fmt::Display for Product"));
         assert!(out.contains("write!(f, \"{:?}\", self)"));
     }
@@ -1211,7 +1306,7 @@ mod tests {
         );
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let _ = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let _ = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(
             ru.contains(RequiredUses::DATETIME),
             "DATETIME flag should be set"
@@ -1223,7 +1318,7 @@ mod tests {
         let model = make_model("Record", vec![make_field("birth_date", "Date", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let _ = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let _ = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(ru.contains(RequiredUses::DATE), "DATE flag should be set");
     }
 
@@ -1232,7 +1327,7 @@ mod tests {
         let model = make_model("Entity", vec![make_field("id", "Uuid", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(ru.contains(RequiredUses::UUID), "UUID flag should be set");
         assert!(out.contains("pub id: Uuid,"));
     }
@@ -1243,7 +1338,7 @@ mod tests {
         let model = make_model("Signal", vec![make_field("type", "String", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(out.contains("r#type"));
         assert!(out.contains("#[serde(rename = \"type\")]"));
     }
@@ -1254,7 +1349,7 @@ mod tests {
         let model = make_model("Obj", vec![make_field("myFieldName", "String", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(out.contains("pub my_field_name: String,"));
         assert!(out.contains("#[serde(rename = \"myFieldName\")]"));
     }
@@ -1270,7 +1365,7 @@ mod tests {
         let model = make_model("Extensible", vec![field]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(out.contains("#[serde(flatten)]"));
     }
 
@@ -1281,7 +1376,7 @@ mod tests {
         let model = make_model("Widget", vec![field]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(out.contains("pub label: Option<String>,"));
     }
 
@@ -1292,7 +1387,7 @@ mod tests {
         let model = make_model("Collection", vec![field]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         assert!(out.contains("pub items: Vec<String>,"));
     }
 
@@ -1304,7 +1399,7 @@ mod tests {
         ]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
         // Default derive must NOT be added when custom derive is already present
         let derive_count = out.matches("#[derive(").count();
         assert_eq!(derive_count, 1, "Only one derive block expected:\n{out}");

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -835,4 +835,742 @@ mod tests {
             "Display impl should be skipped when x-rust-attrs already has Display:\n{output}"
         );
     }
+
+    // ─── to_snake_case ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_to_snake_case_camel_case() {
+        assert_eq!(to_snake_case("camelCase"), "camel_case");
+        assert_eq!(to_snake_case("myFieldName"), "my_field_name");
+    }
+
+    #[test]
+    fn test_to_snake_case_pascal_case() {
+        assert_eq!(to_snake_case("PascalCase"), "pascal_case");
+        assert_eq!(to_snake_case("MyModel"), "my_model");
+    }
+
+    #[test]
+    fn test_to_snake_case_already_snake() {
+        assert_eq!(to_snake_case("snake_case"), "snake_case");
+    }
+
+    #[test]
+    fn test_to_snake_case_self_reserved() {
+        // "Self" -> "self" which is a keyword → appended with '_'
+        assert_eq!(to_snake_case("Self"), "self_");
+    }
+
+    #[test]
+    fn test_to_snake_case_digit_start() {
+        // A leading digit must be prefixed with '_'
+        assert_eq!(to_snake_case("123field"), "_123field");
+    }
+
+    #[test]
+    fn test_to_snake_case_special_chars_become_underscore() {
+        assert_eq!(to_snake_case("field-name"), "field_name");
+        assert_eq!(to_snake_case("field.name"), "field_name");
+    }
+
+    #[test]
+    fn test_to_snake_case_collapses_double_underscore() {
+        // Special chars produce underscores; consecutive underscores are collapsed
+        assert_eq!(to_snake_case("field__name"), "field_name");
+    }
+
+    // ─── is_reserved_word ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_reserved_word_fn_keyword() {
+        assert!(is_reserved_word("fn"));
+        assert!(is_reserved_word("type"));
+        assert!(is_reserved_word("struct"));
+        assert!(is_reserved_word("while"));
+        // raw identifier prefix "r#" is not stripped, so "r#fn" does NOT match
+        assert!(!is_reserved_word("r#fn"));
+    }
+
+    #[test]
+    fn test_is_reserved_word_not_keyword() {
+        assert!(!is_reserved_word("name"));
+        assert!(!is_reserved_word("id"));
+        assert!(!is_reserved_word("value"));
+    }
+
+    // ─── has_custom_derive / has_custom_serde ────────────────────────────────
+
+    #[test]
+    fn test_has_custom_derive_true() {
+        let attrs = Some(vec!["#[derive(Hash)]".to_string()]);
+        assert!(has_custom_derive(&attrs));
+    }
+
+    #[test]
+    fn test_has_custom_derive_false_other_attr() {
+        let attrs = Some(vec!["#[serde(rename_all = \"camelCase\")]".to_string()]);
+        assert!(!has_custom_derive(&attrs));
+    }
+
+    #[test]
+    fn test_has_custom_derive_none() {
+        assert!(!has_custom_derive(&None));
+    }
+
+    #[test]
+    fn test_has_custom_serde_true() {
+        let attrs = Some(vec!["#[serde(rename_all = \"camelCase\")]".to_string()]);
+        assert!(has_custom_serde(&attrs));
+    }
+
+    #[test]
+    fn test_has_custom_serde_false() {
+        let attrs = Some(vec!["#[derive(Hash)]".to_string()]);
+        assert!(!has_custom_serde(&attrs));
+    }
+
+    // ─── generate_custom_attrs ───────────────────────────────────────────────
+
+    #[test]
+    fn test_generate_custom_attrs_some() {
+        let attrs = Some(vec!["#[derive(Hash)]".to_string(), "#[serde(rename_all = \"camelCase\")]".to_string()]);
+        let out = generate_custom_attrs(&attrs);
+        assert!(out.contains("#[derive(Hash)]\n"));
+        assert!(out.contains("#[serde(rename_all = \"camelCase\")]\n"));
+    }
+
+    #[test]
+    fn test_generate_custom_attrs_none() {
+        assert_eq!(generate_custom_attrs(&None), "");
+    }
+
+    // ─── generate_description_docs ───────────────────────────────────────────
+
+    #[test]
+    fn test_generate_description_docs_with_description() {
+        let desc = Some("A description.\nSecond line.".to_string());
+        let out = generate_description_docs(&desc, "Fallback", "");
+        assert!(out.contains("/// A description."));
+        assert!(out.contains("/// Second line."));
+        assert!(!out.contains("Fallback"));
+    }
+
+    #[test]
+    fn test_generate_description_docs_uses_fallback() {
+        let out = generate_description_docs(&None, "FallbackName", "");
+        assert!(out.contains("/// FallbackName"));
+    }
+
+    #[test]
+    fn test_generate_description_docs_empty_fallback_produces_empty() {
+        let out = generate_description_docs(&None, "", "");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_generate_description_docs_with_indent() {
+        let desc = Some("My field".to_string());
+        let out = generate_description_docs(&desc, "", "    ");
+        assert!(out.starts_with("    /// My field"));
+    }
+
+    // ─── generate_display_impl ───────────────────────────────────────────────
+
+    #[test]
+    fn test_generate_display_impl_skipped_when_display_in_custom_attrs() {
+        let attrs = Some(vec!["#[derive(Display, Debug)]".to_string()]);
+        let out = generate_display_impl("MyType", &attrs, "        write!(f, \"{:?}\", self)\n");
+        assert!(out.is_empty(), "Should be empty when Display attr is present");
+    }
+
+    #[test]
+    fn test_generate_display_impl_generated_when_no_custom_attrs() {
+        let out = generate_display_impl("MyType", &None, "        write!(f, \"{:?}\", self)\n");
+        assert!(out.contains("impl std::fmt::Display for MyType"));
+        assert!(out.contains("write!(f, \"{:?}\", self)"));
+    }
+
+    // ─── generate_validator_attrs ────────────────────────────────────────────
+
+    #[test]
+    fn test_generate_validator_attrs_string_min_max_length() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            min_length: Some(1),
+            max_length: Some(100),
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "String");
+        assert!(out.contains("#[validate(length("));
+        assert!(out.contains("min = 1"));
+        assert!(out.contains("max = 100"));
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_string_email() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            email: true,
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "String");
+        assert!(out.contains("#[validate(email)]\n"));
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_string_url() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            url: true,
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "Option<String>");
+        assert!(out.contains("#[validate(url)]\n"));
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_string_pattern() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            pattern: Some(r"^\d+$".to_string()),
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "String");
+        assert!(out.contains("#[regex(pattern = r\""));
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_number_range() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            minimum: Some(0.0),
+            maximum: Some(255.0),
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "i64");
+        assert!(out.contains("#[validate(range("));
+        assert!(out.contains("min = 0"));
+        assert!(out.contains("max = 255"));
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_array_items() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            min_items: Some(1),
+            max_items: Some(10),
+            ..Default::default()
+        };
+        let out = generate_validator_attrs(&rules, "Vec<String>");
+        assert!(out.contains("#[validate(length("));
+        assert!(out.contains("min = 1"));
+        assert!(out.contains("max = 10"));
+    }
+
+    #[test]
+    fn test_generate_validator_attrs_unknown_type_returns_empty() {
+        use crate::models::ValidationRules;
+        let rules = ValidationRules {
+            minimum: Some(1.0),
+            ..Default::default()
+        };
+        // Custom type that doesn't match any arm → no output
+        let out = generate_validator_attrs(&rules, "MyCustomType");
+        assert!(out.is_empty());
+    }
+
+    // ─── generate_model ──────────────────────────────────────────────────────
+
+    fn make_field(name: &str, field_type: &str, is_required: bool) -> crate::models::Field {
+        crate::models::Field {
+            name: name.to_string(),
+            field_type: field_type.to_string(),
+            format: "string".to_string(),
+            is_required,
+            is_nullable: false,
+            is_array_ref: false,
+            description: None,
+            custom_attrs: None,
+            validation_rules: None,
+        }
+    }
+
+    fn make_model(name: &str, fields: Vec<crate::models::Field>) -> crate::models::Model {
+        crate::models::Model {
+            name: name.to_string(),
+            fields,
+            custom_attrs: None,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn test_generate_model_basic_struct() {
+        let model = make_model("User", vec![
+            make_field("id", "String", true),
+            make_field("age", "i64", false),
+        ]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(out.contains("pub struct User {"));
+        assert!(out.contains("pub id: String,"));
+        assert!(out.contains("pub age: Option<i64>,"));
+        assert!(out.contains("#[derive(Debug, Clone, Serialize, Deserialize)]"));
+        assert!(!out.contains("impl std::fmt::Display"));
+    }
+
+    #[test]
+    fn test_generate_model_with_display() {
+        let model = make_model("Product", vec![make_field("name", "String", true)]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, true).expect("generate_model failed");
+        assert!(out.contains("impl std::fmt::Display for Product"));
+        assert!(out.contains("write!(f, \"{:?}\", self)"));
+    }
+
+    #[test]
+    fn test_generate_model_datetime_field_sets_import_flag() {
+        let model = make_model("Event", vec![make_field("created_at", "DateTime<Utc>", true)]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let _ = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(ru.contains(RequiredUses::DATETIME), "DATETIME flag should be set");
+    }
+
+    #[test]
+    fn test_generate_model_date_field_sets_import_flag() {
+        let model = make_model("Record", vec![make_field("birth_date", "Date", true)]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let _ = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(ru.contains(RequiredUses::DATE), "DATE flag should be set");
+    }
+
+    #[test]
+    fn test_generate_model_uuid_field_sets_import_flag() {
+        let model = make_model("Entity", vec![make_field("id", "Uuid", true)]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(ru.contains(RequiredUses::UUID), "UUID flag should be set");
+        assert!(out.contains("pub id: Uuid,"));
+    }
+
+    #[test]
+    fn test_generate_model_reserved_field_name_gets_raw_prefix() {
+        // "type" is a reserved word → r#type
+        let model = make_model("Signal", vec![make_field("type", "String", true)]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(out.contains("r#type"));
+        assert!(out.contains("#[serde(rename = \"type\")]"));
+    }
+
+    #[test]
+    fn test_generate_model_serde_rename_when_name_differs() {
+        // camelCase field name gets snake_case rename
+        let model = make_model("Obj", vec![make_field("myFieldName", "String", true)]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(out.contains("pub my_field_name: String,"));
+        assert!(out.contains("#[serde(rename = \"myFieldName\")]"));
+    }
+
+    #[test]
+    fn test_generate_model_flatten_additional_properties() {
+        let mut field = make_field("additional_properties", "std::collections::HashMap<String, serde_json::Value>", false);
+        field.is_required = true;
+        let model = make_model("Extensible", vec![field]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(out.contains("#[serde(flatten)]"));
+    }
+
+    #[test]
+    fn test_generate_model_nullable_field_becomes_option() {
+        let mut field = make_field("label", "String", true);
+        field.is_nullable = true;
+        let model = make_model("Widget", vec![field]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(out.contains("pub label: Option<String>,"));
+    }
+
+    #[test]
+    fn test_generate_model_array_ref_field() {
+        let mut field = make_field("items", "String", true);
+        field.is_array_ref = true;
+        let model = make_model("Collection", vec![field]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        assert!(out.contains("pub items: Vec<String>,"));
+    }
+
+    #[test]
+    fn test_generate_model_custom_derive_not_doubled() {
+        let mut model = make_model("Custom", vec![make_field("x", "i64", true)]);
+        model.custom_attrs = Some(vec!["#[derive(Hash, Eq, Debug, Clone, Serialize, Deserialize)]".to_string()]);
+        let mut ru = RequiredUses::empty();
+        let mut nv = false;
+        let out = generate_model(&model, &mut ru, &mut nv, false).expect("generate_model failed");
+        // Default derive must NOT be added when custom derive is already present
+        let derive_count = out.matches("#[derive(").count();
+        assert_eq!(derive_count, 1, "Only one derive block expected:\n{out}");
+    }
+
+    // ─── generate_composition ────────────────────────────────────────────────
+
+    #[test]
+    fn test_generate_composition_basic() {
+        use crate::models::CompositionModel;
+        let comp = CompositionModel {
+            name: "PersonComposed".to_string(),
+            all_fields: vec![
+                make_field("name", "String", true),
+                make_field("age", "i64", false),
+            ],
+            custom_attrs: None,
+        };
+        let mut ru = RequiredUses::empty();
+        let out = generate_composition(&comp, &mut ru, false).expect("generate_composition failed");
+        assert!(out.contains("pub struct PersonComposed {"));
+        assert!(out.contains("pub name: String,"));
+        assert!(out.contains("pub age: Option<i64>,"));
+        assert!(out.contains("/// PersonComposed (allOf composition)"));
+    }
+
+    #[test]
+    fn test_generate_composition_with_display() {
+        use crate::models::CompositionModel;
+        let comp = CompositionModel {
+            name: "Base".to_string(),
+            all_fields: vec![make_field("id", "String", true)],
+            custom_attrs: None,
+        };
+        let mut ru = RequiredUses::empty();
+        let out = generate_composition(&comp, &mut ru, true).expect("generate_composition failed");
+        assert!(out.contains("impl std::fmt::Display for Base"));
+    }
+
+    // ─── generate_union ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_generate_union_oneof() {
+        use crate::models::{UnionModel, UnionType, UnionVariant};
+        let union = UnionModel {
+            name: "MyUnion".to_string(),
+            variants: vec![
+                UnionVariant { name: "VariantA".to_string(), fields: vec![], primitive_type: None },
+                UnionVariant { name: "VariantB".to_string(), fields: vec![], primitive_type: None },
+            ],
+            union_type: UnionType::OneOf,
+            custom_attrs: None,
+        };
+        let out = generate_union(&union, false).expect("generate_union failed");
+        assert!(out.contains("/// MyUnion (oneOf)"));
+        assert!(out.contains("pub enum MyUnion {"));
+        assert!(out.contains("VariantA(VariantA),"));
+        assert!(out.contains("VariantB(VariantB),"));
+        assert!(out.contains("#[serde(untagged)]"));
+    }
+
+    #[test]
+    fn test_generate_union_anyof() {
+        use crate::models::{UnionModel, UnionType, UnionVariant};
+        let union = UnionModel {
+            name: "AnyOfUnion".to_string(),
+            variants: vec![
+                UnionVariant { name: "Opt1".to_string(), fields: vec![], primitive_type: None },
+            ],
+            union_type: UnionType::AnyOf,
+            custom_attrs: None,
+        };
+        let out = generate_union(&union, false).expect("generate_union failed");
+        assert!(out.contains("/// AnyOfUnion (anyOf)"));
+    }
+
+    #[test]
+    fn test_generate_union_with_display() {
+        use crate::models::{UnionModel, UnionType, UnionVariant};
+        let union = UnionModel {
+            name: "PaymentMethod".to_string(),
+            variants: vec![
+                UnionVariant { name: "Card".to_string(), fields: vec![], primitive_type: None },
+                UnionVariant { name: "Cash".to_string(), fields: vec![], primitive_type: None },
+            ],
+            union_type: UnionType::OneOf,
+            custom_attrs: None,
+        };
+        let out = generate_union(&union, true).expect("generate_union failed");
+        assert!(out.contains("impl std::fmt::Display for PaymentMethod"));
+        assert!(out.contains("Self::Card(inner) => write!(f, \"{}\", inner)"));
+    }
+
+    #[test]
+    fn test_generate_union_with_primitive_type() {
+        use crate::models::{UnionModel, UnionType, UnionVariant};
+        let union = UnionModel {
+            name: "StringOrInt".to_string(),
+            variants: vec![
+                UnionVariant { name: "StringVariant".to_string(), fields: vec![], primitive_type: Some("String".to_string()) },
+                UnionVariant { name: "IntVariant".to_string(), fields: vec![], primitive_type: Some("i64".to_string()) },
+            ],
+            union_type: UnionType::OneOf,
+            custom_attrs: None,
+        };
+        let out = generate_union(&union, false).expect("generate_union failed");
+        assert!(out.contains("StringVariant(String),"));
+        assert!(out.contains("IntVariant(i64),"));
+    }
+
+    // ─── generate_type_alias ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_generate_type_alias_basic() {
+        use crate::models::TypeAliasModel;
+        let alias = TypeAliasModel {
+            name: "UserId".to_string(),
+            target_type: "uuid::Uuid".to_string(),
+            description: None,
+            custom_attrs: None,
+        };
+        let out = generate_type_alias(&alias).expect("generate_type_alias failed");
+        assert!(out.contains("pub type UserId = uuid::Uuid;"));
+    }
+
+    #[test]
+    fn test_generate_type_alias_with_description() {
+        use crate::models::TypeAliasModel;
+        let alias = TypeAliasModel {
+            name: "Tags".to_string(),
+            target_type: "Vec<String>".to_string(),
+            description: Some("A list of tags".to_string()),
+            custom_attrs: None,
+        };
+        let out = generate_type_alias(&alias).expect("generate_type_alias failed");
+        assert!(out.contains("/// A list of tags"));
+        assert!(out.contains("pub type Tags = Vec<String>;"));
+    }
+
+    // ─── generate_request_model / generate_response_model ───────────────────
+
+    #[test]
+    fn test_generate_request_model_basic() {
+        use crate::models::RequestModel;
+        let req = RequestModel {
+            name: "CreateUserRequest".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "CreateUserRequestBody".to_string(),
+            is_required: true,
+        };
+        let out = generate_request_model(&req).expect("generate_request_model failed");
+        assert!(out.contains("pub struct CreateUserRequest {"));
+        assert!(out.contains("pub body: CreateUserRequestBody,"));
+    }
+
+    #[test]
+    fn test_generate_request_model_empty_name_skipped() {
+        use crate::models::RequestModel;
+        let req = RequestModel {
+            name: "".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "SomeSchema".to_string(),
+            is_required: false,
+        };
+        let out = generate_request_model(&req).expect("generate_request_model failed");
+        assert!(out.is_empty(), "Empty-named request should produce no code");
+    }
+
+    #[test]
+    fn test_generate_request_model_unknown_name_skipped() {
+        use crate::models::RequestModel;
+        let req = RequestModel {
+            name: EMPTY_REQUEST_NAME.to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Schema".to_string(),
+            is_required: false,
+        };
+        let out = generate_request_model(&req).expect("generate_request_model failed");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_generate_response_model_basic() {
+        use crate::models::ResponseModel;
+        let resp = ResponseModel {
+            name: "GetUserResponse".to_string(),
+            status_code: "200".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "User".to_string(),
+            description: Some("Successful response".to_string()),
+        };
+        let out = generate_response_model(&resp).expect("generate_response_model failed");
+        assert!(out.contains("pub struct GetUserResponse200 {"));
+        assert!(out.contains("pub body: User,"));
+        assert!(out.contains("/// Successful response"));
+    }
+
+    #[test]
+    fn test_generate_response_model_unknown_name_skipped() {
+        use crate::models::ResponseModel;
+        let resp = ResponseModel {
+            name: EMPTY_RESPONSE_NAME.to_string(),
+            status_code: "200".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "User".to_string(),
+            description: None,
+        };
+        let out = generate_response_model(&resp).expect("generate_response_model failed");
+        assert!(out.is_empty());
+    }
+
+    // ─── generate_models (public API) ────────────────────────────────────────
+
+    #[test]
+    fn test_generate_models_always_includes_serde_import() {
+        let out = generate_models(&[], &[], &[], GenerateMode::MODELS, false)
+            .expect("generate_models failed");
+        assert!(out.contains("use serde::{Serialize, Deserialize};"));
+    }
+
+    #[test]
+    fn test_generate_models_models_only_mode_skips_requests_and_responses() {
+        use crate::models::{RequestModel, ResponseModel};
+        let requests = vec![RequestModel {
+            name: "CreateFooRequest".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            is_required: true,
+        }];
+        let responses = vec![ResponseModel {
+            name: "GetFooResponse".to_string(),
+            status_code: "200".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            description: None,
+        }];
+        let out = generate_models(&[], &requests, &responses, GenerateMode::MODELS, false)
+            .expect("generate_models failed");
+        assert!(!out.contains("CreateFooRequest"), "MODELS mode must not emit request types");
+        assert!(!out.contains("GetFooResponse200"), "MODELS mode must not emit response types");
+    }
+
+    #[test]
+    fn test_generate_models_all_mode_includes_requests_and_responses() {
+        use crate::models::{RequestModel, ResponseModel};
+        let requests = vec![RequestModel {
+            name: "CreateFooRequest".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            is_required: true,
+        }];
+        let responses = vec![ResponseModel {
+            name: "GetFooResponse".to_string(),
+            status_code: "200".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            description: None,
+        }];
+        let out = generate_models(&[], &requests, &responses, GenerateMode::ALL, false)
+            .expect("generate_models failed");
+        assert!(out.contains("CreateFooRequest"));
+        assert!(out.contains("GetFooResponse200"));
+    }
+
+    #[test]
+    fn test_generate_models_requests_mode_includes_only_requests() {
+        use crate::models::{RequestModel, ResponseModel};
+        let requests = vec![RequestModel {
+            name: "CreateFooRequest".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            is_required: true,
+        }];
+        let responses = vec![ResponseModel {
+            name: "GetFooResponse".to_string(),
+            status_code: "200".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            description: None,
+        }];
+        let out = generate_models(&[], &requests, &responses, GenerateMode::REQUESTS, false)
+            .expect("generate_models failed");
+        assert!(out.contains("CreateFooRequest"), "REQUESTS mode should emit requests");
+        assert!(!out.contains("GetFooResponse200"), "REQUESTS mode should not emit responses");
+    }
+
+    #[test]
+    fn test_generate_models_responses_mode_includes_only_responses() {
+        use crate::models::{RequestModel, ResponseModel};
+        let requests = vec![RequestModel {
+            name: "CreateFooRequest".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            is_required: true,
+        }];
+        let responses = vec![ResponseModel {
+            name: "GetFooResponse".to_string(),
+            status_code: "200".to_string(),
+            content_type: "application/json".to_string(),
+            schema: "Foo".to_string(),
+            description: None,
+        }];
+        let out = generate_models(&[], &requests, &responses, GenerateMode::RESPONSES, false)
+            .expect("generate_models failed");
+        assert!(!out.contains("CreateFooRequest"), "RESPONSES mode should not emit requests");
+        assert!(out.contains("GetFooResponse200"), "RESPONSES mode should emit responses");
+    }
+
+    #[test]
+    fn test_generate_models_adds_chrono_import_for_datetime_field() {
+        let models = vec![ModelType::Struct(make_model(
+            "Event",
+            vec![make_field("created_at", "DateTime<Utc>", true)],
+        ))];
+        let out = generate_models(&models, &[], &[], GenerateMode::MODELS, false)
+            .expect("generate_models failed");
+        assert!(out.contains("use chrono::{"));
+        assert!(out.contains("DateTime"));
+        assert!(out.contains("Utc"));
+    }
+
+    #[test]
+    fn test_generate_models_adds_uuid_import_for_uuid_field() {
+        let models = vec![ModelType::Struct(make_model(
+            "Entity",
+            vec![make_field("id", "Uuid", true)],
+        ))];
+        let out = generate_models(&models, &[], &[], GenerateMode::MODELS, false)
+            .expect("generate_models failed");
+        assert!(out.contains("use uuid::Uuid;"));
+    }
+
+    #[test]
+    fn test_generate_models_adds_validator_import_when_validation_rules_present() {
+        use crate::models::ValidationRules;
+        let mut field = make_field("name", "String", true);
+        field.validation_rules = Some(ValidationRules {
+            min_length: Some(1),
+            max_length: Some(50),
+            ..Default::default()
+        });
+        let models = vec![ModelType::Struct(make_model("Validated", vec![field]))];
+        let out = generate_models(&models, &[], &[], GenerateMode::MODELS, false)
+            .expect("generate_models failed");
+        assert!(out.contains("use validator::Validate;"));
+        assert!(out.contains("Validate"));
+    }
+
+    #[test]
+    fn test_generate_lib() {
+        let out = generate_lib().expect("generate_lib failed");
+        assert!(out.contains("pub mod models;"));
+    }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1162,8 +1162,14 @@ mod tests {
         let out = generate_validator_attrs(&rules, "f64", &mut IndexMap::new());
         assert!(out.contains("#[validate(range("));
         // Must use float literals (0.0, 1.0) not integer literals (0, 1)
-        assert!(out.contains("min = 0.0"), "expected float literal 'min = 0.0', got:\n{out}");
-        assert!(out.contains("max = 1.0"), "expected float literal 'max = 1.0', got:\n{out}");
+        assert!(
+            out.contains("min = 0.0"),
+            "expected float literal 'min = 0.0', got:\n{out}"
+        );
+        assert!(
+            out.contains("max = 1.0"),
+            "expected float literal 'max = 1.0', got:\n{out}"
+        );
     }
 
     #[test]
@@ -1176,8 +1182,14 @@ mod tests {
         };
         let out = generate_validator_attrs(&rules, "f32", &mut IndexMap::new());
         assert!(out.contains("#[validate(range("));
-        assert!(out.contains("min = 0.5"), "expected 'min = 0.5', got:\n{out}");
-        assert!(out.contains("max = 100.5"), "expected 'max = 100.5', got:\n{out}");
+        assert!(
+            out.contains("min = 0.5"),
+            "expected 'min = 0.5', got:\n{out}"
+        );
+        assert!(
+            out.contains("max = 100.5"),
+            "expected 'max = 100.5', got:\n{out}"
+        );
     }
 
     #[test]
@@ -1190,11 +1202,19 @@ mod tests {
             ..Default::default()
         };
         let out = generate_validator_attrs(&rules, "f64", &mut IndexMap::new());
-        assert!(out.contains("min = 5.0"), "expected 'min = 5.0', got:\n{out}");
-        assert!(out.contains("max = 255.0"), "expected 'max = 255.0', got:\n{out}");
+        assert!(
+            out.contains("min = 5.0"),
+            "expected 'min = 5.0', got:\n{out}"
+        );
+        assert!(
+            out.contains("max = 255.0"),
+            "expected 'max = 255.0', got:\n{out}"
+        );
         // Ensure integer literals are NOT present
-        assert!(!out.contains("min = 5,") && !out.contains("min = 5)"),
-            "integer literal found in float range attr:\n{out}");
+        assert!(
+            !out.contains("min = 5,") && !out.contains("min = 5)"),
+            "integer literal found in float range attr:\n{out}"
+        );
     }
 
     #[test]
@@ -1207,8 +1227,10 @@ mod tests {
         let mut registry = IndexMap::new();
         let out = generate_validator_attrs(&rules, "String", &mut registry);
         // Must emit validate(regex(path = RE_N)) not #[regex(pattern = ...)]
-        assert!(out.contains("#[validate(regex(path = RE_1))]"),
-            "expected regex(path = RE_1), got:\n{out}");
+        assert!(
+            out.contains("#[validate(regex(path = RE_1))]"),
+            "expected regex(path = RE_1), got:\n{out}"
+        );
         assert_eq!(registry.len(), 1);
         assert_eq!(registry.get(r"^[a-z]+$"), Some(&"RE_1".to_string()));
     }
@@ -1227,16 +1249,29 @@ mod tests {
         // Second field with same pattern reuses RE_1
         let out2 = generate_validator_attrs(&rules, "String", &mut registry);
         assert!(out1.contains("RE_1"));
-        assert!(out2.contains("RE_1"), "identical pattern should reuse RE_1, got:\n{out2}");
-        assert_eq!(registry.len(), 1, "duplicate pattern must not add a second entry");
+        assert!(
+            out2.contains("RE_1"),
+            "identical pattern should reuse RE_1, got:\n{out2}"
+        );
+        assert_eq!(
+            registry.len(),
+            1,
+            "duplicate pattern must not add a second entry"
+        );
     }
 
     #[test]
     fn test_generate_validator_attrs_distinct_patterns_get_separate_statics() {
         use crate::models::ValidationRules;
         let mut registry = IndexMap::new();
-        let rules1 = ValidationRules { pattern: Some(r"^a+$".to_string()), ..Default::default() };
-        let rules2 = ValidationRules { pattern: Some(r"^b+$".to_string()), ..Default::default() };
+        let rules1 = ValidationRules {
+            pattern: Some(r"^a+$".to_string()),
+            ..Default::default()
+        };
+        let rules2 = ValidationRules {
+            pattern: Some(r"^b+$".to_string()),
+            ..Default::default()
+        };
         let out1 = generate_validator_attrs(&rules1, "String", &mut registry);
         let out2 = generate_validator_attrs(&rules2, "String", &mut registry);
         assert!(out1.contains("RE_1"));
@@ -1280,7 +1315,8 @@ mod tests {
         );
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(out.contains("pub struct User {"));
         assert!(out.contains("pub id: String,"));
         assert!(out.contains("pub age: Option<i64>,"));
@@ -1293,7 +1329,8 @@ mod tests {
         let model = make_model("Product", vec![make_field("name", "String", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), true).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), true)
+            .expect("generate_model failed");
         assert!(out.contains("impl std::fmt::Display for Product"));
         assert!(out.contains("write!(f, \"{:?}\", self)"));
     }
@@ -1306,7 +1343,8 @@ mod tests {
         );
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let _ = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let _ = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(
             ru.contains(RequiredUses::DATETIME),
             "DATETIME flag should be set"
@@ -1318,7 +1356,8 @@ mod tests {
         let model = make_model("Record", vec![make_field("birth_date", "Date", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let _ = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let _ = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(ru.contains(RequiredUses::DATE), "DATE flag should be set");
     }
 
@@ -1327,7 +1366,8 @@ mod tests {
         let model = make_model("Entity", vec![make_field("id", "Uuid", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(ru.contains(RequiredUses::UUID), "UUID flag should be set");
         assert!(out.contains("pub id: Uuid,"));
     }
@@ -1338,7 +1378,8 @@ mod tests {
         let model = make_model("Signal", vec![make_field("type", "String", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(out.contains("r#type"));
         assert!(out.contains("#[serde(rename = \"type\")]"));
     }
@@ -1349,7 +1390,8 @@ mod tests {
         let model = make_model("Obj", vec![make_field("myFieldName", "String", true)]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(out.contains("pub my_field_name: String,"));
         assert!(out.contains("#[serde(rename = \"myFieldName\")]"));
     }
@@ -1365,7 +1407,8 @@ mod tests {
         let model = make_model("Extensible", vec![field]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(out.contains("#[serde(flatten)]"));
     }
 
@@ -1376,7 +1419,8 @@ mod tests {
         let model = make_model("Widget", vec![field]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(out.contains("pub label: Option<String>,"));
     }
 
@@ -1387,7 +1431,8 @@ mod tests {
         let model = make_model("Collection", vec![field]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         assert!(out.contains("pub items: Vec<String>,"));
     }
 
@@ -1399,7 +1444,8 @@ mod tests {
         ]);
         let mut ru = RequiredUses::empty();
         let mut nv = false;
-        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false).expect("generate_model failed");
+        let out = generate_model(&model, &mut ru, &mut nv, &mut IndexMap::new(), false)
+            .expect("generate_model failed");
         // Default derive must NOT be added when custom derive is already present
         let derive_count = out.matches("#[derive(").count();
         assert_eq!(derive_count, 1, "Only one derive block expected:\n{out}");

--- a/src/models.rs
+++ b/src/models.rs
@@ -155,3 +155,166 @@ impl ValidationRules {
             || self.unique_items
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── ModelType::name ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_model_type_name_struct() {
+        let m = ModelType::Struct(Model {
+            name: "MyStruct".to_string(),
+            fields: vec![],
+            custom_attrs: None,
+            description: None,
+        });
+        assert_eq!(m.name(), "MyStruct");
+    }
+
+    #[test]
+    fn test_model_type_name_enum() {
+        let m = ModelType::Enum(EnumModel {
+            name: "MyEnum".to_string(),
+            variants: vec![],
+            description: None,
+            custom_attrs: None,
+        });
+        assert_eq!(m.name(), "MyEnum");
+    }
+
+    #[test]
+    fn test_model_type_name_union() {
+        let m = ModelType::Union(UnionModel {
+            name: "MyUnion".to_string(),
+            variants: vec![],
+            union_type: UnionType::OneOf,
+            custom_attrs: None,
+        });
+        assert_eq!(m.name(), "MyUnion");
+    }
+
+    #[test]
+    fn test_model_type_name_composition() {
+        let m = ModelType::Composition(CompositionModel {
+            name: "MyComposition".to_string(),
+            all_fields: vec![],
+            custom_attrs: None,
+        });
+        assert_eq!(m.name(), "MyComposition");
+    }
+
+    #[test]
+    fn test_model_type_name_type_alias() {
+        let m = ModelType::TypeAlias(TypeAliasModel {
+            name: "MyAlias".to_string(),
+            target_type: "String".to_string(),
+            description: None,
+            custom_attrs: None,
+        });
+        assert_eq!(m.name(), "MyAlias");
+    }
+
+    // ─── Field::should_flatten ───────────────────────────────────────────────
+
+    #[test]
+    fn test_field_should_flatten_true_for_additional_properties() {
+        let field = Field {
+            name: "additional_properties".to_string(),
+            field_type: "std::collections::HashMap<String, serde_json::Value>".to_string(),
+            format: "".to_string(),
+            is_required: false,
+            is_nullable: false,
+            is_array_ref: false,
+            description: None,
+            custom_attrs: None,
+            validation_rules: None,
+        };
+        assert!(field.should_flatten());
+    }
+
+    #[test]
+    fn test_field_should_flatten_false_for_regular_field() {
+        let field = Field {
+            name: "user_id".to_string(),
+            field_type: "String".to_string(),
+            format: "".to_string(),
+            is_required: true,
+            is_nullable: false,
+            is_array_ref: false,
+            description: None,
+            custom_attrs: None,
+            validation_rules: None,
+        };
+        assert!(!field.should_flatten());
+    }
+
+    // ─── ValidationRules::has_any ────────────────────────────────────────────
+
+    #[test]
+    fn test_validation_rules_has_any_default_is_false() {
+        let rules = ValidationRules::default();
+        assert!(!rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_min_length() {
+        let rules = ValidationRules { min_length: Some(1), ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_max_length() {
+        let rules = ValidationRules { max_length: Some(100), ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_pattern() {
+        let rules = ValidationRules { pattern: Some(r"^\d+$".to_string()), ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_email() {
+        let rules = ValidationRules { email: true, ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_url() {
+        let rules = ValidationRules { url: true, ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_minimum() {
+        let rules = ValidationRules { minimum: Some(0.0), ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_exclusive_minimum() {
+        let rules = ValidationRules { exclusive_minimum: true, ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_multiple_of() {
+        let rules = ValidationRules { multiple_of: Some(5.0), ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_min_items() {
+        let rules = ValidationRules { min_items: Some(1), ..Default::default() };
+        assert!(rules.has_any());
+    }
+
+    #[test]
+    fn test_validation_rules_has_any_unique_items() {
+        let rules = ValidationRules { unique_items: true, ..Default::default() };
+        assert!(rules.has_any());
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2369,4 +2369,385 @@ mod tests {
             panic!("Expected Widget to be a Struct");
         }
     }
+
+    // ─── to_pascal_case ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_to_pascal_case_lowercase() {
+        assert_eq!(to_pascal_case("user"), "User");
+    }
+
+    #[test]
+    fn test_to_pascal_case_camel_case() {
+        assert_eq!(to_pascal_case("createRole"), "CreateRole");
+    }
+
+    #[test]
+    fn test_to_pascal_case_with_hyphen() {
+        assert_eq!(to_pascal_case("list-roles"), "ListRoles");
+    }
+
+    #[test]
+    fn test_to_pascal_case_with_underscore() {
+        assert_eq!(to_pascal_case("list_roles"), "ListRoles");
+    }
+
+    #[test]
+    fn test_to_pascal_case_already_pascal() {
+        assert_eq!(to_pascal_case("PascalCase"), "PascalCase");
+    }
+
+    #[test]
+    fn test_to_pascal_case_empty_string() {
+        assert_eq!(to_pascal_case(""), "");
+    }
+
+    #[test]
+    fn test_to_pascal_case_mixed_delimiters() {
+        assert_eq!(to_pascal_case("listRoles-Input"), "ListRolesInput");
+    }
+
+    // ─── Additional schema parsing tests ─────────────────────────────────────
+
+    #[test]
+    fn test_parse_enum_string_schema() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Color": {
+                        "type": "string",
+                        "enum": ["red", "green", "blue"]
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let color = models.iter().find(|m| m.name() == "Color");
+        assert!(color.is_some(), "Expected Color enum");
+        match color.unwrap() {
+            ModelType::Enum(e) => {
+                assert_eq!(e.variants.len(), 3);
+                assert!(e.variants.contains(&"red".to_string()));
+                assert!(e.variants.contains(&"green".to_string()));
+                assert!(e.variants.contains(&"blue".to_string()));
+            }
+            _ => panic!("Expected Enum for Color"),
+        }
+    }
+
+    #[test]
+    fn test_parse_oneof_schema_produces_union() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Cat": { "type": "object", "properties": { "meow": { "type": "string" } } },
+                    "Dog": { "type": "object", "properties": { "bark": { "type": "string" } } },
+                    "Pet": {
+                        "oneOf": [
+                            { "$ref": "#/components/schemas/Cat" },
+                            { "$ref": "#/components/schemas/Dog" }
+                        ]
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let pet = models.iter().find(|m| m.name() == "Pet");
+        assert!(pet.is_some(), "Expected Pet union");
+        match pet.unwrap() {
+            ModelType::Union(u) => {
+                assert_eq!(u.variants.len(), 2);
+            }
+            _ => panic!("Expected Union for Pet"),
+        }
+    }
+
+    #[test]
+    fn test_parse_anyof_schema_produces_union() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Notification": {
+                        "anyOf": [
+                            { "type": "object", "properties": { "email": { "type": "string" } } },
+                            { "type": "object", "properties": { "sms": { "type": "string" } } }
+                        ]
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let notif = models.iter().find(|m| m.name() == "Notification");
+        assert!(notif.is_some(), "Expected Notification union");
+        match notif.unwrap() {
+            ModelType::Union(u) => {
+                use crate::models::UnionType;
+                assert!(matches!(u.union_type, UnionType::AnyOf));
+            }
+            _ => panic!("Expected Union (anyOf) for Notification"),
+        }
+    }
+
+    #[test]
+    fn test_parse_object_with_additional_properties_produces_type_alias() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Metadata": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let meta = models.iter().find(|m| m.name() == "Metadata");
+        assert!(meta.is_some(), "Expected Metadata model");
+        match meta.unwrap() {
+            ModelType::TypeAlias(alias) => {
+                assert!(alias.target_type.contains("HashMap<String, String>"));
+            }
+            _ => panic!("Expected TypeAlias for Metadata (additionalProperties only object)"),
+        }
+    }
+
+    #[test]
+    fn test_parse_array_schema_produces_type_alias() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "UserIds": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let user_ids = models.iter().find(|m| m.name() == "UserIds");
+        assert!(user_ids.is_some(), "Expected UserIds type alias");
+        match user_ids.unwrap() {
+            ModelType::TypeAlias(alias) => {
+                assert!(alias.target_type.contains("Vec<String>"));
+            }
+            _ => panic!("Expected TypeAlias for UserIds (array schema)"),
+        }
+    }
+
+    #[test]
+    fn test_parse_empty_object_produces_empty_struct() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "EmptyModel": {
+                        "type": "object"
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let empty = models.iter().find(|m| m.name() == "EmptyModel");
+        assert!(empty.is_some(), "Expected EmptyModel");
+        match empty.unwrap() {
+            ModelType::Struct(s) => {
+                assert!(s.fields.is_empty(), "Empty object should produce struct with no fields");
+            }
+            _ => panic!("Expected Struct for EmptyModel"),
+        }
+    }
+
+    #[test]
+    fn test_parse_response_schema_from_path() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {
+                "/users/{id}": {
+                    "get": {
+                        "operationId": "getUser",
+                        "responses": {
+                            "200": {
+                                "description": "The user",
+                                "content": {
+                                    "application/json": {
+                                        "schema": { "$ref": "#/components/schemas/User" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "User": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string" },
+                            "name": { "type": "string" }
+                        },
+                        "required": ["id"]
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _requests, responses) = parse_openapi(&openapi_spec).expect("Failed to parse");
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].name, "GetUserResponse");
+        assert_eq!(responses[0].status_code, "200");
+
+        let user = models.iter().find(|m| m.name() == "User");
+        assert!(user.is_some(), "User model should be generated from components");
+    }
+
+    #[test]
+    fn test_parse_struct_with_description() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Order": {
+                        "type": "object",
+                        "description": "Represents a purchase order",
+                        "properties": {
+                            "id": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let order = models.iter().find(|m| m.name() == "Order");
+        assert!(order.is_some());
+        match order.unwrap() {
+            ModelType::Struct(s) => {
+                assert_eq!(s.description, Some("Represents a purchase order".to_string()));
+            }
+            _ => panic!("Expected Struct for Order"),
+        }
+    }
+
+    #[test]
+    fn test_parse_field_with_validation_rules() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Account": {
+                        "type": "object",
+                        "properties": {
+                            "username": {
+                                "type": "string",
+                                "minLength": 3,
+                                "maxLength": 30
+                            },
+                            "age": {
+                                "type": "integer",
+                                "minimum": 18,
+                                "maximum": 120
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+        let account = models.iter().find(|m| m.name() == "Account");
+        assert!(account.is_some(), "Expected Account model");
+        if let Some(ModelType::Struct(s)) = account {
+            let username = s.fields.iter().find(|f| f.name == "username").unwrap();
+            assert!(username.validation_rules.is_some());
+            let rules = username.validation_rules.as_ref().unwrap();
+            assert_eq!(rules.min_length, Some(3));
+            assert_eq!(rules.max_length, Some(30));
+
+            let age = s.fields.iter().find(|f| f.name == "age").unwrap();
+            assert!(age.validation_rules.is_some());
+            let rules = age.validation_rules.as_ref().unwrap();
+            assert_eq!(rules.minimum, Some(18.0));
+            assert_eq!(rules.maximum, Some(120.0));
+        } else {
+            panic!("Expected Struct for Account");
+        }
+    }
+
+    #[test]
+    fn test_parse_array_items_with_oneof_produces_union_and_alias() {
+        let openapi_spec: OpenAPI = serde_json::from_value(json!({
+            "openapi": "3.0.0",
+            "info": { "title": "Test", "version": "1.0.0" },
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "Events": {
+                        "type": "array",
+                        "items": {
+                            "oneOf": [
+                                { "type": "object", "properties": { "click": { "type": "string" } } },
+                                { "type": "object", "properties": { "scroll": { "type": "string" } } }
+                            ]
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("Failed to parse spec");
+
+        let (models, _, _) = parse_openapi(&openapi_spec).expect("Failed to parse");
+
+        // Should generate both EventsItem (union) and Events (type alias Vec<EventsItem>)
+        let events = models.iter().find(|m| m.name() == "Events");
+        assert!(events.is_some(), "Expected Events type alias");
+        match events.unwrap() {
+            ModelType::TypeAlias(alias) => {
+                assert!(alias.target_type.contains("Vec<EventsItem>"));
+            }
+            _ => panic!("Expected TypeAlias for Events"),
+        }
+
+        let events_item = models.iter().find(|m| m.name() == "EventsItem");
+        assert!(events_item.is_some(), "Expected EventsItem union");
+        assert!(matches!(events_item.unwrap(), ModelType::Union(_)));
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,613 @@
+/// Integration tests for the full parse → generate pipeline.
+///
+/// These tests use only the public API:
+///   - `openapi_model_generator::parse_openapi`
+///   - `openapi_model_generator::generate_models`
+///   - `openapi_model_generator::GenerateMode`
+use openapi_model_generator::{generate_models, parse_openapi, GenerateMode};
+use openapiv3::OpenAPI;
+use serde_json::json;
+
+fn parse_spec(value: serde_json::Value) -> OpenAPI {
+    serde_json::from_value(value).expect("Failed to deserialize OpenAPI spec")
+}
+
+// ─── Basic struct generation ─────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_simple_struct() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id":    { "type": "string" },
+                        "email": { "type": "string" },
+                        "age":   { "type": "integer" }
+                    },
+                    "required": ["id", "email"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub struct User {"), "Expected struct User:\n{code}");
+    assert!(code.contains("pub id: String,"), "id must be non-optional:\n{code}");
+    assert!(code.contains("pub email: String,"), "email must be non-optional:\n{code}");
+    assert!(code.contains("pub age: Option<i64>,"), "age must be optional:\n{code}");
+    assert!(code.contains("use serde::{Serialize, Deserialize};"));
+}
+
+// ─── Enum generation ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_enum() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Status": {
+                    "type": "string",
+                    "enum": ["pending", "active", "inactive"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub enum Status {"), "Expected enum Status:\n{code}");
+    assert!(code.contains("Pending"), "Expected Pending variant:\n{code}");
+    assert!(code.contains("Active"), "Expected Active variant:\n{code}");
+    assert!(code.contains("Inactive"), "Expected Inactive variant:\n{code}");
+}
+
+// ─── allOf composition ───────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_allof_composition() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Base": {
+                    "type": "object",
+                    "properties": { "id": { "type": "string" } },
+                    "required": ["id"]
+                },
+                "Extended": {
+                    "allOf": [
+                        { "$ref": "#/components/schemas/Base" },
+                        {
+                            "type": "object",
+                            "properties": { "extra": { "type": "string" } }
+                        }
+                    ]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub struct Extended {"), "Expected Extended struct:\n{code}");
+    assert!(code.contains("pub id: String,"), "id should be non-optional (required in Base):\n{code}");
+    assert!(code.contains("pub extra: Option<String>,"), "extra should be optional:\n{code}");
+    assert!(code.contains("/// Extended (allOf composition)"));
+}
+
+// ─── oneOf union ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_oneof_union() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Cat": { "type": "object", "properties": { "meow": { "type": "string" } } },
+                "Dog": { "type": "object", "properties": { "bark": { "type": "string" } } },
+                "Pet": {
+                    "oneOf": [
+                        { "$ref": "#/components/schemas/Cat" },
+                        { "$ref": "#/components/schemas/Dog" }
+                    ]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub enum Pet {"), "Expected Pet enum:\n{code}");
+    assert!(code.contains("#[serde(untagged)]"), "oneOf must be untagged:\n{code}");
+    assert!(code.contains("/// Pet (oneOf)"), "Expected oneOf doc comment:\n{code}");
+}
+
+// ─── anyOf union ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_anyof_union() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Alert": {
+                    "anyOf": [
+                        { "type": "object", "properties": { "email": { "type": "string" } } },
+                        { "type": "object", "properties": { "sms":   { "type": "string" } } }
+                    ]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub enum Alert {"), "Expected Alert enum:\n{code}");
+    assert!(code.contains("/// Alert (anyOf)"), "Expected anyOf doc comment:\n{code}");
+}
+
+// ─── Type alias (x-rust-type) ────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_type_alias_from_x_rust_type() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "UserId": {
+                    "type": "string",
+                    "format": "uuid",
+                    "x-rust-type": "uuid::Uuid"
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub type UserId = uuid::Uuid;"), "Expected type alias:\n{code}");
+}
+
+// ─── Request and response generation ─────────────────────────────────────────
+
+#[test]
+fn test_pipeline_requests_and_responses_with_all_mode() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {
+            "/users": {
+                "post": {
+                    "operationId": "createUser",
+                    "requestBody": {
+                        "required": true,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": { "type": "string" }
+                                    },
+                                    "required": ["name"]
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/User" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id":   { "type": "string" },
+                        "name": { "type": "string" }
+                    },
+                    "required": ["id"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::ALL, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub struct CreateUserRequest {"), "Expected request struct:\n{code}");
+    assert!(code.contains("pub struct CreateUserResponse201 {"), "Expected response struct:\n{code}");
+    assert!(code.contains("pub struct User {"), "Expected User model:\n{code}");
+}
+
+#[test]
+fn test_pipeline_models_only_mode_omits_request_response() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {
+            "/items": {
+                "post": {
+                    "operationId": "createItem",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": { "$ref": "#/components/schemas/Item" }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "OK",
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/Item" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Item": {
+                    "type": "object",
+                    "properties": { "name": { "type": "string" } }
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(!code.contains("CreateItemRequest"), "MODELS mode must not emit request types:\n{code}");
+    assert!(!code.contains("CreateItemResponse"), "MODELS mode must not emit response types:\n{code}");
+    assert!(code.contains("pub struct Item {"), "Item model should still be generated:\n{code}");
+}
+
+// ─── Display flag ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_display_flag_adds_display_impl() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Role": {
+                    "type": "string",
+                    "enum": ["admin", "user", "guest"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+
+    let code_with_display =
+        generate_models(&models, &requests, &responses, GenerateMode::MODELS, true)
+            .expect("generate_models failed");
+    assert!(
+        code_with_display.contains("impl std::fmt::Display for Role"),
+        "Display flag should add Display impl:\n{code_with_display}"
+    );
+
+    let code_without_display =
+        generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+            .expect("generate_models failed");
+    assert!(
+        !code_without_display.contains("impl std::fmt::Display"),
+        "Display flag off should not add Display impl:\n{code_without_display}"
+    );
+}
+
+// ─── Chrono / UUID imports ────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_chrono_import_added_for_datetime_field() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Event": {
+                    "type": "object",
+                    "properties": {
+                        "occurred_at": { "type": "string", "format": "date-time" }
+                    },
+                    "required": ["occurred_at"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("use chrono::{"), "Expected chrono import:\n{code}");
+    assert!(code.contains("DateTime"), "Expected DateTime in chrono import:\n{code}");
+    assert!(code.contains("pub occurred_at: DateTime<Utc>,"), "Expected DateTime<Utc> field:\n{code}");
+}
+
+#[test]
+fn test_pipeline_date_import_added_for_date_field() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Schedule": {
+                    "type": "object",
+                    "properties": {
+                        "date": { "type": "string", "format": "date" }
+                    },
+                    "required": ["date"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("NaiveDate"), "Expected NaiveDate import:\n{code}");
+    assert!(code.contains("pub date: NaiveDate,"), "Expected NaiveDate field:\n{code}");
+}
+
+#[test]
+fn test_pipeline_uuid_import_added_for_uuid_field() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Resource": {
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string", "format": "uuid" }
+                    },
+                    "required": ["id"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("use uuid::Uuid;"), "Expected uuid import:\n{code}");
+    assert!(code.contains("pub id: Uuid,"), "Expected Uuid field:\n{code}");
+}
+
+// ─── No duplicate models for repeated schemas ─────────────────────────────────
+
+#[test]
+fn test_pipeline_no_duplicate_models() {
+    // The same schema referenced multiple times must produce a single model.
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Tag": {
+                    "type": "object",
+                    "properties": { "name": { "type": "string" } }
+                },
+                "Article": {
+                    "type": "object",
+                    "properties": {
+                        "primary_tag":   { "$ref": "#/components/schemas/Tag" },
+                        "secondary_tag": { "$ref": "#/components/schemas/Tag" }
+                    }
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    // "pub struct Tag {" must appear exactly once
+    let count = code.matches("pub struct Tag {").count();
+    assert_eq!(count, 1, "Tag struct should appear exactly once:\n{code}");
+}
+
+// ─── Inline nested objects ────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_inline_nested_object_generates_struct() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Order": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "object",
+                            "properties": {
+                                "street": { "type": "string" },
+                                "city":   { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub struct Order {"), "Expected Order struct:\n{code}");
+    assert!(code.contains("pub struct Address {"), "Expected inline Address struct:\n{code}");
+}
+
+// ─── Custom attributes (x-rust-attrs) ────────────────────────────────────────
+
+#[test]
+fn test_pipeline_x_rust_attrs_applied_to_generated_struct() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Config": {
+                    "type": "object",
+                    "x-rust-attrs": ["#[derive(Hash, Eq, PartialEq)]"],
+                    "properties": {
+                        "key": { "type": "string" }
+                    }
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(
+        code.contains("#[derive(Hash, Eq, PartialEq)]"),
+        "Custom x-rust-attrs must appear in output:\n{code}"
+    );
+}
+
+// ─── YAML parsing ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_parse_from_yaml_string() {
+    let yaml = r#"
+openapi: "3.0.0"
+info:
+  title: YAML Test API
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      properties:
+        name:
+          type: string
+        count:
+          type: integer
+      required:
+        - name
+"#;
+
+    let openapi: OpenAPI = serde_yaml::from_str(yaml).expect("Failed to parse YAML");
+    let (models, requests, responses) = parse_openapi(&openapi).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub struct Widget {"), "Expected Widget struct from YAML spec:\n{code}");
+    assert!(code.contains("pub name: String,"));
+    assert!(code.contains("pub count: Option<i64>,"));
+}
+
+// ─── Error: empty spec ───────────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_empty_spec_produces_no_models() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Empty API", "version": "1.0.0" },
+        "paths": {}
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    assert!(models.is_empty(), "Empty spec should produce no models");
+    assert!(requests.is_empty());
+    assert!(responses.is_empty());
+
+    let code = generate_models(&models, &requests, &responses, GenerateMode::ALL, false)
+        .expect("generate_models failed");
+    assert!(code.contains("use serde::{Serialize, Deserialize};"), "Should still have serde import");
+}
+
+// ─── Boolean and number fields ────────────────────────────────────────────────
+
+#[test]
+fn test_pipeline_boolean_and_number_fields() {
+    let spec = parse_spec(json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test API", "version": "1.0.0" },
+        "paths": {},
+        "components": {
+            "schemas": {
+                "Settings": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": { "type": "boolean" },
+                        "ratio":   { "type": "number" },
+                        "count":   { "type": "integer" }
+                    },
+                    "required": ["enabled", "ratio", "count"]
+                }
+            }
+        }
+    }));
+
+    let (models, requests, responses) = parse_openapi(&spec).expect("parse_openapi failed");
+    let code = generate_models(&models, &requests, &responses, GenerateMode::MODELS, false)
+        .expect("generate_models failed");
+
+    assert!(code.contains("pub enabled: bool,"), "Expected bool field:\n{code}");
+    assert!(code.contains("pub ratio: f64,"), "Expected f64 field:\n{code}");
+    assert!(code.contains("pub count: i64,"), "Expected i64 field:\n{code}");
+}


### PR DESCRIPTION
PS C:\docs\src\rust\openapi-model-generator> cargo llvm-cov
info: cargo-llvm-cov currently setting cfg(coverage); you can opt-out it by passing --no-cfg-coverage
   Compiling openapi-model-generator v0.6.2 (C:\docs\src\rust\openapi-model-generator)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 19.48s                                                                                                                                                   
     Running unittests src\lib.rs (target\llvm-cov-target\debug\deps\openapi_model_generator-b35021f687b5b826.exe)

running 124 tests
test generator::tests::test_enum_no_display_when_flag_off ... ok
test generator::tests::test_enum_no_display_when_custom_attrs_has_display ... ok
test generator::tests::test_generate_composition_basic ... ok
test generator::tests::test_generate_composition_with_display ... ok
test generator::tests::test_enum_display_escapes_quotes_and_backslashes ... ok
test generator::tests::test_generate_custom_attrs_none ... ok
test generator::tests::test_generate_custom_attrs_some ... ok
test generator::tests::test_generate_description_docs_empty_fallback_produces_empty ... ok
test generator::tests::test_generate_description_docs_uses_fallback ... ok
test generator::tests::test_generate_description_docs_with_description ... ok
test generator::tests::test_generate_description_docs_with_indent ... ok
test generator::tests::test_generate_display_impl_generated_when_no_custom_attrs ... ok
test generator::tests::test_generate_display_impl_skipped_when_display_in_custom_attrs ... ok
test generator::tests::test_generate_model_array_ref_field ... ok
test generator::tests::test_generate_lib ... ok
test generator::tests::test_generate_model_basic_struct ... ok
test generator::tests::test_generate_model_custom_derive_not_doubled ... ok
test generator::tests::test_generate_model_date_field_sets_import_flag ... ok
test generator::tests::test_generate_model_datetime_field_sets_import_flag ... ok
test generator::tests::test_generate_model_flatten_additional_properties ... ok
test generator::tests::test_generate_model_nullable_field_becomes_option ... ok
test generator::tests::test_generate_model_reserved_field_name_gets_raw_prefix ... ok
test generator::tests::test_generate_model_serde_rename_when_name_differs ... ok
test generator::tests::test_generate_model_uuid_field_sets_import_flag ... ok
test generator::tests::test_generate_model_with_display ... ok
test generator::tests::test_generate_models_adds_uuid_import_for_uuid_field ... ok
test generator::tests::test_generate_models_adds_chrono_import_for_datetime_field ... ok
test generator::tests::test_generate_models_adds_validator_import_when_validation_rules_present ... ok
test generator::tests::test_generate_models_models_only_mode_skips_requests_and_responses ... ok
test generator::tests::test_generate_models_requests_mode_includes_only_requests ... ok
test generator::tests::test_generate_models_all_mode_includes_requests_and_responses ... ok
test generator::tests::test_generate_models_always_includes_serde_import ... ok
test generator::tests::test_generate_models_responses_mode_includes_only_responses ... ok
test generator::tests::test_generate_request_model_empty_name_skipped ... ok
test generator::tests::test_generate_request_model_basic ... ok
test generator::tests::test_generate_request_model_unknown_name_skipped ... ok
test generator::tests::test_generate_response_model_basic ... ok
test generator::tests::test_generate_response_model_unknown_name_skipped ... ok
test generator::tests::test_generate_type_alias_basic ... ok
test generator::tests::test_generate_union_anyof ... ok
test generator::tests::test_generate_type_alias_with_description ... ok
test generator::tests::test_generate_union_oneof ... ok
test generator::tests::test_generate_union_with_display ... ok
test generator::tests::test_generate_union_with_primitive_type ... ok
test generator::tests::test_generate_validator_attrs_array_items ... ok
test generator::tests::test_generate_validator_attrs_number_range ... ok
test generator::tests::test_generate_validator_attrs_string_email ... ok
test generator::tests::test_generate_validator_attrs_string_min_max_length ... ok
test generator::tests::test_generate_validator_attrs_unknown_type_returns_empty ... ok
test generator::tests::test_has_custom_derive_false_other_attr ... ok
test generator::tests::test_generate_validator_attrs_string_pattern ... ok
test generator::tests::test_generate_validator_attrs_string_url ... ok
test generator::tests::test_has_custom_derive_true ... ok
test generator::tests::test_has_custom_serde_false ... ok
test generator::tests::test_has_custom_derive_none ... ok
test generator::tests::test_has_custom_serde_true ... ok
test generator::tests::test_is_reserved_word_fn_keyword ... ok
test generator::tests::test_is_reserved_word_not_keyword ... ok
test generator::tests::test_to_snake_case_already_snake ... ok
test generator::tests::test_to_snake_case_camel_case ... ok
test generator::tests::test_to_snake_case_collapses_double_underscore ... ok
test generator::tests::test_to_snake_case_digit_start ... ok
test generator::tests::test_to_snake_case_pascal_case ... ok
test generator::tests::test_to_snake_case_self_reserved ... ok
test generator::tests::test_to_snake_case_special_chars_become_underscore ... ok
test models::tests::test_field_should_flatten_false_for_regular_field ... ok
test models::tests::test_field_should_flatten_true_for_additional_properties ... ok
test models::tests::test_model_type_name_composition ... ok
test models::tests::test_model_type_name_enum ... ok
test models::tests::test_model_type_name_struct ... ok
test models::tests::test_model_type_name_union ... ok
test models::tests::test_model_type_name_type_alias ... ok
test models::tests::test_validation_rules_has_any_default_is_false ... ok
test models::tests::test_validation_rules_has_any_email ... ok
test models::tests::test_validation_rules_has_any_exclusive_minimum ... ok
test models::tests::test_validation_rules_has_any_max_length ... ok
test models::tests::test_validation_rules_has_any_min_items ... ok
test models::tests::test_validation_rules_has_any_min_length ... ok
test models::tests::test_validation_rules_has_any_minimum ... ok
test models::tests::test_validation_rules_has_any_multiple_of ... ok
test models::tests::test_validation_rules_has_any_pattern ... ok
test models::tests::test_validation_rules_has_any_url ... ok
test models::tests::test_validation_rules_has_any_unique_items ... ok
test parser::tests::test_allof_primitive_field_narrowed_to_specific_type ... ok
test parser::tests::test_allof_required_fields_merge ... ok
test parser::tests::test_inline_enum_fields_on_different_structs_get_unique_names ... ok
test parser::tests::test_inline_nullable_field_is_optional ... ok
test parser::tests::test_multiple_properties_with_x_rust_type ... ok
test parser::tests::test_nullable_reference_field ... ok
test parser::tests::test_parse_anyof_schema_produces_union ... ok
test parser::tests::test_parse_empty_object_produces_empty_struct ... ok
test parser::tests::test_parse_array_schema_produces_type_alias ... ok
test parser::tests::test_parse_array_items_with_oneof_produces_union_and_alias ... ok
test parser::tests::test_parse_enum_string_schema ... ok
test parser::tests::test_parse_field_with_validation_rules ... ok
test parser::tests::test_parse_inline_request_body_generates_model ... ok
test parser::tests::test_parse_oneof_schema_produces_union ... ok
test parser::tests::test_parse_ref_request_body_works ... ok
test parser::tests::test_parse_object_with_additional_properties_produces_type_alias ... ok
test parser::tests::test_schema_level_nullable_ref_makes_field_optional ... ok
test parser::tests::test_to_pascal_case_already_pascal ... ok
test parser::tests::test_parse_struct_with_description ... ok
test parser::tests::test_parse_response_schema_from_path ... ok
test parser::tests::test_parse_no_request_body ... ok
test parser::tests::test_to_pascal_case_camel_case ... ok
test parser::tests::test_to_pascal_case_lowercase ... ok
test parser::tests::test_to_pascal_case_mixed_delimiters ... ok
test parser::tests::test_to_pascal_case_empty_string ... ok
test parser::tests::test_to_pascal_case_with_hyphen ... ok
test parser::tests::test_to_pascal_case_with_underscore ... ok
test parser::tests::test_x_rust_attrs_empty_array ... ok
test parser::tests::test_x_rust_attrs_on_enum ... ok
test parser::tests::test_x_rust_attrs_from_ref_target_not_propagated_to_field ... ok
test parser::tests::test_x_rust_attrs_on_field ... ok
test parser::tests::test_x_rust_attrs_on_inline_enum_field_go_to_enum_not_field ... ok
test parser::tests::test_x_rust_attrs_on_struct ... ok
test parser::tests::test_x_rust_type_generates_type_alias ... ok
test parser::tests::test_x_rust_attrs_with_x_rust_type ... ok
test parser::tests::test_x_rust_type_on_integer_property ... ok
test parser::tests::test_x_rust_type_on_nullable_property ... ok
test parser::tests::test_x_rust_type_works_with_enum ... ok
test parser::tests::test_x_rust_type_on_number_property ... ok
test parser::tests::test_x_rust_type_on_string_property ... ok
test parser::tests::test_x_rust_type_works_with_oneof ... ok

test result: ok. 124 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s

     Running unittests src\main.rs (target\llvm-cov-target\debug\deps\omg-656b5a9073c3f371.exe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests\integration_test.rs (target\llvm-cov-target\debug\deps\integration_test-d667bb32b5f34b2b.exe)

running 18 tests
test test_pipeline_anyof_union ... ok
test test_pipeline_date_import_added_for_date_field ... ok
test test_pipeline_boolean_and_number_fields ... ok
test test_pipeline_chrono_import_added_for_datetime_field ... ok
test test_pipeline_display_flag_adds_display_impl ... ok
test test_pipeline_empty_spec_produces_no_models ... ok
test test_pipeline_allof_composition ... ok
test test_pipeline_enum ... ok
test test_pipeline_no_duplicate_models ... ok
test test_pipeline_oneof_union ... ok
test test_pipeline_simple_struct ... ok
test test_pipeline_inline_nested_object_generates_struct ... ok
test test_pipeline_models_only_mode_omits_request_response ... ok
test test_pipeline_parse_from_yaml_string ... ok
test test_pipeline_type_alias_from_x_rust_type ... ok
test test_pipeline_requests_and_responses_with_all_mode ... ok
test test_pipeline_uuid_import_added_for_uuid_field ... ok
test test_pipeline_x_rust_attrs_applied_to_generated_struct ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```
Filename                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
cli.rs                              7                 7     0.00%           1                 1     0.00%           7                 7     0.00%           0                 0         -
generator.rs                     1927               130    93.25%          98                 2    97.96%        1132                72    93.64%           0                 0         -
main.rs                            99                99     0.00%           5                 5     0.00%          67                67     0.00%           0                 0         -
models.rs                         192                 0   100.00%          21                 0   100.00%         142                 0   100.00%           0                 0         -
parser.rs                        3161               439    86.11%         150                15    90.00%        1924               320    83.37%           0                 0         -
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                            5386               675    87.47%         275                23    91.64%        3272               466    85.76%           0                 0         -
```